### PR TITLE
Add package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "pygments-css",
+  "version": "1.0.0",
+  "description": "CSS stylesheets for pygments",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/richleland/pygments-css.git"
+  },
+  "keywords": ["pygments", "css", "highlighting"],
+  "license": "UNLICENSE",
+  "bugs": {
+    "url": "https://github.com/richleland/pygments-css/issues"
+  },
+  "homepage": "https://github.com/richleland/pygments-css#readme"
+}


### PR DESCRIPTION
This adds a package.json file so `pygments-css` can be installed with npm. Various build modules like [postcss-import](https://github.com/postcss/postcss-import) can read from `node_modules` so a theme can be used like `@import pygments-css/monokai`.

I also just published this to npm as `pygments-css` and added you as an owner :smile: And if you're not aware this module powers our highlighting (along with pygments of course) at Bitbucket :tada: 