### PR TITLE
Sync to latest Pygments

### DIFF
--- a/abap.css
+++ b/abap.css
@@ -1,0 +1,65 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; }
+.highlight .c { color: #888888; font-style: italic } /* Comment */
+.highlight .err { color: #FF0000 } /* Error */
+.highlight .k { color: #0000ff } /* Keyword */
+.highlight .n { color: #000000 } /* Name */
+.highlight .ch { color: #888888; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #888888; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #888888; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #888888; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #888888; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #888888; font-style: italic } /* Comment.Special */
+.highlight .kc { color: #0000ff } /* Keyword.Constant */
+.highlight .kd { color: #0000ff } /* Keyword.Declaration */
+.highlight .kn { color: #0000ff } /* Keyword.Namespace */
+.highlight .kp { color: #0000ff } /* Keyword.Pseudo */
+.highlight .kr { color: #0000ff } /* Keyword.Reserved */
+.highlight .kt { color: #0000ff } /* Keyword.Type */
+.highlight .m { color: #33aaff } /* Literal.Number */
+.highlight .s { color: #55aa22 } /* Literal.String */
+.highlight .na { color: #000000 } /* Name.Attribute */
+.highlight .nb { color: #000000 } /* Name.Builtin */
+.highlight .nc { color: #000000 } /* Name.Class */
+.highlight .no { color: #000000 } /* Name.Constant */
+.highlight .nd { color: #000000 } /* Name.Decorator */
+.highlight .ni { color: #000000 } /* Name.Entity */
+.highlight .ne { color: #000000 } /* Name.Exception */
+.highlight .nf { color: #000000 } /* Name.Function */
+.highlight .nl { color: #000000 } /* Name.Label */
+.highlight .nn { color: #000000 } /* Name.Namespace */
+.highlight .nx { color: #000000 } /* Name.Other */
+.highlight .py { color: #000000 } /* Name.Property */
+.highlight .nt { color: #000000 } /* Name.Tag */
+.highlight .nv { color: #000000 } /* Name.Variable */
+.highlight .ow { color: #0000ff } /* Operator.Word */
+.highlight .mb { color: #33aaff } /* Literal.Number.Bin */
+.highlight .mf { color: #33aaff } /* Literal.Number.Float */
+.highlight .mh { color: #33aaff } /* Literal.Number.Hex */
+.highlight .mi { color: #33aaff } /* Literal.Number.Integer */
+.highlight .mo { color: #33aaff } /* Literal.Number.Oct */
+.highlight .sa { color: #55aa22 } /* Literal.String.Affix */
+.highlight .sb { color: #55aa22 } /* Literal.String.Backtick */
+.highlight .sc { color: #55aa22 } /* Literal.String.Char */
+.highlight .dl { color: #55aa22 } /* Literal.String.Delimiter */
+.highlight .sd { color: #55aa22 } /* Literal.String.Doc */
+.highlight .s2 { color: #55aa22 } /* Literal.String.Double */
+.highlight .se { color: #55aa22 } /* Literal.String.Escape */
+.highlight .sh { color: #55aa22 } /* Literal.String.Heredoc */
+.highlight .si { color: #55aa22 } /* Literal.String.Interpol */
+.highlight .sx { color: #55aa22 } /* Literal.String.Other */
+.highlight .sr { color: #55aa22 } /* Literal.String.Regex */
+.highlight .s1 { color: #55aa22 } /* Literal.String.Single */
+.highlight .ss { color: #55aa22 } /* Literal.String.Symbol */
+.highlight .bp { color: #000000 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #000000 } /* Name.Function.Magic */
+.highlight .vc { color: #000000 } /* Name.Variable.Class */
+.highlight .vg { color: #000000 } /* Name.Variable.Global */
+.highlight .vi { color: #000000 } /* Name.Variable.Instance */
+.highlight .vm { color: #000000 } /* Name.Variable.Magic */
+.highlight .il { color: #33aaff } /* Literal.Number.Integer.Long */

--- a/algol.css
+++ b/algol.css
@@ -1,0 +1,49 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; }
+.highlight .c { color: #888888; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight .k { font-weight: bold; text-decoration: underline } /* Keyword */
+.highlight .ch { color: #888888; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #888888; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #888888; font-weight: bold } /* Comment.Preproc */
+.highlight .cpf { color: #888888; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #888888; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #888888; font-weight: bold } /* Comment.Special */
+.highlight .kc { font-weight: bold; text-decoration: underline } /* Keyword.Constant */
+.highlight .kd { font-weight: bold; font-style: italic; text-decoration: underline } /* Keyword.Declaration */
+.highlight .kn { font-weight: bold; text-decoration: underline } /* Keyword.Namespace */
+.highlight .kp { font-weight: bold; text-decoration: underline } /* Keyword.Pseudo */
+.highlight .kr { font-weight: bold; text-decoration: underline } /* Keyword.Reserved */
+.highlight .kt { font-weight: bold; text-decoration: underline } /* Keyword.Type */
+.highlight .s { color: #666666; font-style: italic } /* Literal.String */
+.highlight .nb { font-weight: bold; font-style: italic } /* Name.Builtin */
+.highlight .nc { color: #666666; font-weight: bold; font-style: italic } /* Name.Class */
+.highlight .no { color: #666666; font-weight: bold; font-style: italic } /* Name.Constant */
+.highlight .nf { color: #666666; font-weight: bold; font-style: italic } /* Name.Function */
+.highlight .nn { color: #666666; font-weight: bold; font-style: italic } /* Name.Namespace */
+.highlight .nv { color: #666666; font-weight: bold; font-style: italic } /* Name.Variable */
+.highlight .ow { font-weight: bold } /* Operator.Word */
+.highlight .sa { color: #666666; font-style: italic } /* Literal.String.Affix */
+.highlight .sb { color: #666666; font-style: italic } /* Literal.String.Backtick */
+.highlight .sc { color: #666666; font-style: italic } /* Literal.String.Char */
+.highlight .dl { color: #666666; font-style: italic } /* Literal.String.Delimiter */
+.highlight .sd { color: #666666; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #666666; font-style: italic } /* Literal.String.Double */
+.highlight .se { color: #666666; font-style: italic } /* Literal.String.Escape */
+.highlight .sh { color: #666666; font-style: italic } /* Literal.String.Heredoc */
+.highlight .si { color: #666666; font-style: italic } /* Literal.String.Interpol */
+.highlight .sx { color: #666666; font-style: italic } /* Literal.String.Other */
+.highlight .sr { color: #666666; font-style: italic } /* Literal.String.Regex */
+.highlight .s1 { color: #666666; font-style: italic } /* Literal.String.Single */
+.highlight .ss { color: #666666; font-style: italic } /* Literal.String.Symbol */
+.highlight .bp { font-weight: bold; font-style: italic } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #666666; font-weight: bold; font-style: italic } /* Name.Function.Magic */
+.highlight .vc { color: #666666; font-weight: bold; font-style: italic } /* Name.Variable.Class */
+.highlight .vg { color: #666666; font-weight: bold; font-style: italic } /* Name.Variable.Global */
+.highlight .vi { color: #666666; font-weight: bold; font-style: italic } /* Name.Variable.Instance */
+.highlight .vm { color: #666666; font-weight: bold; font-style: italic } /* Name.Variable.Magic */

--- a/algol_nu.css
+++ b/algol_nu.css
@@ -1,0 +1,49 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; }
+.highlight .c { color: #888888; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight .k { font-weight: bold } /* Keyword */
+.highlight .ch { color: #888888; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #888888; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #888888; font-weight: bold } /* Comment.Preproc */
+.highlight .cpf { color: #888888; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #888888; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #888888; font-weight: bold } /* Comment.Special */
+.highlight .kc { font-weight: bold } /* Keyword.Constant */
+.highlight .kd { font-weight: bold; font-style: italic } /* Keyword.Declaration */
+.highlight .kn { font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { font-weight: bold } /* Keyword.Pseudo */
+.highlight .kr { font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { font-weight: bold } /* Keyword.Type */
+.highlight .s { color: #666666; font-style: italic } /* Literal.String */
+.highlight .nb { font-weight: bold; font-style: italic } /* Name.Builtin */
+.highlight .nc { color: #666666; font-weight: bold; font-style: italic } /* Name.Class */
+.highlight .no { color: #666666; font-weight: bold; font-style: italic } /* Name.Constant */
+.highlight .nf { color: #666666; font-weight: bold; font-style: italic } /* Name.Function */
+.highlight .nn { color: #666666; font-weight: bold; font-style: italic } /* Name.Namespace */
+.highlight .nv { color: #666666; font-weight: bold; font-style: italic } /* Name.Variable */
+.highlight .ow { font-weight: bold } /* Operator.Word */
+.highlight .sa { color: #666666; font-style: italic } /* Literal.String.Affix */
+.highlight .sb { color: #666666; font-style: italic } /* Literal.String.Backtick */
+.highlight .sc { color: #666666; font-style: italic } /* Literal.String.Char */
+.highlight .dl { color: #666666; font-style: italic } /* Literal.String.Delimiter */
+.highlight .sd { color: #666666; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #666666; font-style: italic } /* Literal.String.Double */
+.highlight .se { color: #666666; font-style: italic } /* Literal.String.Escape */
+.highlight .sh { color: #666666; font-style: italic } /* Literal.String.Heredoc */
+.highlight .si { color: #666666; font-style: italic } /* Literal.String.Interpol */
+.highlight .sx { color: #666666; font-style: italic } /* Literal.String.Other */
+.highlight .sr { color: #666666; font-style: italic } /* Literal.String.Regex */
+.highlight .s1 { color: #666666; font-style: italic } /* Literal.String.Single */
+.highlight .ss { color: #666666; font-style: italic } /* Literal.String.Symbol */
+.highlight .bp { font-weight: bold; font-style: italic } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #666666; font-weight: bold; font-style: italic } /* Name.Function.Magic */
+.highlight .vc { color: #666666; font-weight: bold; font-style: italic } /* Name.Variable.Class */
+.highlight .vg { color: #666666; font-weight: bold; font-style: italic } /* Name.Variable.Global */
+.highlight .vi { color: #666666; font-weight: bold; font-style: italic } /* Name.Variable.Instance */
+.highlight .vm { color: #666666; font-weight: bold; font-style: italic } /* Name.Variable.Magic */

--- a/arduino.css
+++ b/arduino.css
@@ -1,0 +1,66 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; }
+.highlight .c { color: #95a5a6 } /* Comment */
+.highlight .err { color: #a61717 } /* Error */
+.highlight .k { color: #728E00 } /* Keyword */
+.highlight .n { color: #434f54 } /* Name */
+.highlight .o { color: #728E00 } /* Operator */
+.highlight .ch { color: #95a5a6 } /* Comment.Hashbang */
+.highlight .cm { color: #95a5a6 } /* Comment.Multiline */
+.highlight .cp { color: #728E00 } /* Comment.Preproc */
+.highlight .cpf { color: #95a5a6 } /* Comment.PreprocFile */
+.highlight .c1 { color: #95a5a6 } /* Comment.Single */
+.highlight .cs { color: #95a5a6 } /* Comment.Special */
+.highlight .kc { color: #00979D } /* Keyword.Constant */
+.highlight .kd { color: #728E00 } /* Keyword.Declaration */
+.highlight .kn { color: #728E00 } /* Keyword.Namespace */
+.highlight .kp { color: #00979D } /* Keyword.Pseudo */
+.highlight .kr { color: #00979D } /* Keyword.Reserved */
+.highlight .kt { color: #00979D } /* Keyword.Type */
+.highlight .m { color: #8A7B52 } /* Literal.Number */
+.highlight .s { color: #7F8C8D } /* Literal.String */
+.highlight .na { color: #434f54 } /* Name.Attribute */
+.highlight .nb { color: #728E00 } /* Name.Builtin */
+.highlight .nc { color: #434f54 } /* Name.Class */
+.highlight .no { color: #434f54 } /* Name.Constant */
+.highlight .nd { color: #434f54 } /* Name.Decorator */
+.highlight .ni { color: #434f54 } /* Name.Entity */
+.highlight .ne { color: #434f54 } /* Name.Exception */
+.highlight .nf { color: #D35400 } /* Name.Function */
+.highlight .nl { color: #434f54 } /* Name.Label */
+.highlight .nn { color: #434f54 } /* Name.Namespace */
+.highlight .nx { color: #728E00 } /* Name.Other */
+.highlight .py { color: #434f54 } /* Name.Property */
+.highlight .nt { color: #434f54 } /* Name.Tag */
+.highlight .nv { color: #434f54 } /* Name.Variable */
+.highlight .ow { color: #728E00 } /* Operator.Word */
+.highlight .mb { color: #8A7B52 } /* Literal.Number.Bin */
+.highlight .mf { color: #8A7B52 } /* Literal.Number.Float */
+.highlight .mh { color: #8A7B52 } /* Literal.Number.Hex */
+.highlight .mi { color: #8A7B52 } /* Literal.Number.Integer */
+.highlight .mo { color: #8A7B52 } /* Literal.Number.Oct */
+.highlight .sa { color: #7F8C8D } /* Literal.String.Affix */
+.highlight .sb { color: #7F8C8D } /* Literal.String.Backtick */
+.highlight .sc { color: #7F8C8D } /* Literal.String.Char */
+.highlight .dl { color: #7F8C8D } /* Literal.String.Delimiter */
+.highlight .sd { color: #7F8C8D } /* Literal.String.Doc */
+.highlight .s2 { color: #7F8C8D } /* Literal.String.Double */
+.highlight .se { color: #7F8C8D } /* Literal.String.Escape */
+.highlight .sh { color: #7F8C8D } /* Literal.String.Heredoc */
+.highlight .si { color: #7F8C8D } /* Literal.String.Interpol */
+.highlight .sx { color: #7F8C8D } /* Literal.String.Other */
+.highlight .sr { color: #7F8C8D } /* Literal.String.Regex */
+.highlight .s1 { color: #7F8C8D } /* Literal.String.Single */
+.highlight .ss { color: #7F8C8D } /* Literal.String.Symbol */
+.highlight .bp { color: #728E00 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #D35400 } /* Name.Function.Magic */
+.highlight .vc { color: #434f54 } /* Name.Variable.Class */
+.highlight .vg { color: #434f54 } /* Name.Variable.Global */
+.highlight .vi { color: #434f54 } /* Name.Variable.Instance */
+.highlight .vm { color: #434f54 } /* Name.Variable.Magic */
+.highlight .il { color: #8A7B52 } /* Literal.Number.Integer.Long */

--- a/autumn.css
+++ b/autumn.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #ffffff; }
+.highlight { background: #ffffff; }
 .highlight .c { color: #aaaaaa; font-style: italic } /* Comment */
 .highlight .err { color: #FF0000; background-color: #FFAAAA } /* Error */
 .highlight .k { color: #0000aa } /* Keyword */

--- a/borland.css
+++ b/borland.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #ffffff; }
+.highlight { background: #ffffff; }
 .highlight .c { color: #008800; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { color: #000080; font-weight: bold } /* Keyword */

--- a/bw.css
+++ b/bw.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #ffffff; }
+.highlight { background: #ffffff; }
 .highlight .c { font-style: italic } /* Comment */
 .highlight .err { border: 1px solid #FF0000 } /* Error */
 .highlight .k { font-weight: bold } /* Keyword */

--- a/colorful.css
+++ b/colorful.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #ffffff; }
+.highlight { background: #ffffff; }
 .highlight .c { color: #888888 } /* Comment */
 .highlight .err { color: #FF0000; background-color: #FFAAAA } /* Error */
 .highlight .k { color: #008800; font-weight: bold } /* Keyword */

--- a/default.css
+++ b/default.css
@@ -1,21 +1,26 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #f8f8f8; }
-.highlight .c { color: #408080; font-style: italic } /* Comment */
+.highlight { background: #f8f8f8; }
+.highlight .c { color: #3D7B7B; font-style: italic } /* Comment */
 .highlight .err { border: 1px solid #FF0000 } /* Error */
 .highlight .k { color: #008000; font-weight: bold } /* Keyword */
 .highlight .o { color: #666666 } /* Operator */
-.highlight .ch { color: #408080; font-style: italic } /* Comment.Hashbang */
-.highlight .cm { color: #408080; font-style: italic } /* Comment.Multiline */
-.highlight .cp { color: #BC7A00 } /* Comment.Preproc */
-.highlight .cpf { color: #408080; font-style: italic } /* Comment.PreprocFile */
-.highlight .c1 { color: #408080; font-style: italic } /* Comment.Single */
-.highlight .cs { color: #408080; font-style: italic } /* Comment.Special */
+.highlight .ch { color: #3D7B7B; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #3D7B7B; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #9C6500 } /* Comment.Preproc */
+.highlight .cpf { color: #3D7B7B; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #3D7B7B; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #3D7B7B; font-style: italic } /* Comment.Special */
 .highlight .gd { color: #A00000 } /* Generic.Deleted */
 .highlight .ge { font-style: italic } /* Generic.Emph */
-.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gr { color: #E40000 } /* Generic.Error */
 .highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight .gi { color: #00A000 } /* Generic.Inserted */
-.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gi { color: #008400 } /* Generic.Inserted */
+.highlight .go { color: #717171 } /* Generic.Output */
 .highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
 .highlight .gs { font-weight: bold } /* Generic.Strong */
 .highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
@@ -28,15 +33,15 @@
 .highlight .kt { color: #B00040 } /* Keyword.Type */
 .highlight .m { color: #666666 } /* Literal.Number */
 .highlight .s { color: #BA2121 } /* Literal.String */
-.highlight .na { color: #7D9029 } /* Name.Attribute */
+.highlight .na { color: #687822 } /* Name.Attribute */
 .highlight .nb { color: #008000 } /* Name.Builtin */
 .highlight .nc { color: #0000FF; font-weight: bold } /* Name.Class */
 .highlight .no { color: #880000 } /* Name.Constant */
 .highlight .nd { color: #AA22FF } /* Name.Decorator */
-.highlight .ni { color: #999999; font-weight: bold } /* Name.Entity */
-.highlight .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.highlight .ni { color: #717171; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #CB3F38; font-weight: bold } /* Name.Exception */
 .highlight .nf { color: #0000FF } /* Name.Function */
-.highlight .nl { color: #A0A000 } /* Name.Label */
+.highlight .nl { color: #767600 } /* Name.Label */
 .highlight .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
 .highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
 .highlight .nv { color: #19177C } /* Name.Variable */
@@ -53,11 +58,11 @@
 .highlight .dl { color: #BA2121 } /* Literal.String.Delimiter */
 .highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
 .highlight .s2 { color: #BA2121 } /* Literal.String.Double */
-.highlight .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.highlight .se { color: #AA5D1F; font-weight: bold } /* Literal.String.Escape */
 .highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
-.highlight .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.highlight .si { color: #A45A77; font-weight: bold } /* Literal.String.Interpol */
 .highlight .sx { color: #008000 } /* Literal.String.Other */
-.highlight .sr { color: #BB6688 } /* Literal.String.Regex */
+.highlight .sr { color: #A45A77 } /* Literal.String.Regex */
 .highlight .s1 { color: #BA2121 } /* Literal.String.Single */
 .highlight .ss { color: #19177C } /* Literal.String.Symbol */
 .highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */

--- a/dracula.css
+++ b/dracula.css
@@ -1,0 +1,83 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: #f1fa8c; background-color: #44475a; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: #f1fa8c; background-color: #44475a; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #50fa7b; background-color: #6272a4; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #50fa7b; background-color: #6272a4; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #44475a }
+.highlight { background: #282a36; color: #f8f8f2 }
+.highlight .c { color: #6272a4 } /* Comment */
+.highlight .err { color: #f8f8f2 } /* Error */
+.highlight .g { color: #f8f8f2 } /* Generic */
+.highlight .k { color: #ff79c6 } /* Keyword */
+.highlight .l { color: #f8f8f2 } /* Literal */
+.highlight .n { color: #f8f8f2 } /* Name */
+.highlight .o { color: #ff79c6 } /* Operator */
+.highlight .x { color: #f8f8f2 } /* Other */
+.highlight .p { color: #f8f8f2 } /* Punctuation */
+.highlight .ch { color: #6272a4 } /* Comment.Hashbang */
+.highlight .cm { color: #6272a4 } /* Comment.Multiline */
+.highlight .cp { color: #ff79c6 } /* Comment.Preproc */
+.highlight .cpf { color: #6272a4 } /* Comment.PreprocFile */
+.highlight .c1 { color: #6272a4 } /* Comment.Single */
+.highlight .cs { color: #6272a4 } /* Comment.Special */
+.highlight .gd { color: #8b080b } /* Generic.Deleted */
+.highlight .ge { color: #f8f8f2; text-decoration: underline } /* Generic.Emph */
+.highlight .gr { color: #f8f8f2 } /* Generic.Error */
+.highlight .gh { color: #f8f8f2; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #f8f8f2; font-weight: bold } /* Generic.Inserted */
+.highlight .go { color: #44475a } /* Generic.Output */
+.highlight .gp { color: #f8f8f2 } /* Generic.Prompt */
+.highlight .gs { color: #f8f8f2 } /* Generic.Strong */
+.highlight .gu { color: #f8f8f2; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #f8f8f2 } /* Generic.Traceback */
+.highlight .kc { color: #ff79c6 } /* Keyword.Constant */
+.highlight .kd { color: #8be9fd; font-style: italic } /* Keyword.Declaration */
+.highlight .kn { color: #ff79c6 } /* Keyword.Namespace */
+.highlight .kp { color: #ff79c6 } /* Keyword.Pseudo */
+.highlight .kr { color: #ff79c6 } /* Keyword.Reserved */
+.highlight .kt { color: #8be9fd } /* Keyword.Type */
+.highlight .ld { color: #f8f8f2 } /* Literal.Date */
+.highlight .m { color: #ffb86c } /* Literal.Number */
+.highlight .s { color: #bd93f9 } /* Literal.String */
+.highlight .na { color: #50fa7b } /* Name.Attribute */
+.highlight .nb { color: #8be9fd; font-style: italic } /* Name.Builtin */
+.highlight .nc { color: #50fa7b } /* Name.Class */
+.highlight .no { color: #f8f8f2 } /* Name.Constant */
+.highlight .nd { color: #f8f8f2 } /* Name.Decorator */
+.highlight .ni { color: #f8f8f2 } /* Name.Entity */
+.highlight .ne { color: #f8f8f2 } /* Name.Exception */
+.highlight .nf { color: #50fa7b } /* Name.Function */
+.highlight .nl { color: #8be9fd; font-style: italic } /* Name.Label */
+.highlight .nn { color: #f8f8f2 } /* Name.Namespace */
+.highlight .nx { color: #f8f8f2 } /* Name.Other */
+.highlight .py { color: #f8f8f2 } /* Name.Property */
+.highlight .nt { color: #ff79c6 } /* Name.Tag */
+.highlight .nv { color: #8be9fd; font-style: italic } /* Name.Variable */
+.highlight .ow { color: #ff79c6 } /* Operator.Word */
+.highlight .pm { color: #f8f8f2 } /* Punctuation.Marker */
+.highlight .w { color: #f8f8f2 } /* Text.Whitespace */
+.highlight .mb { color: #ffb86c } /* Literal.Number.Bin */
+.highlight .mf { color: #ffb86c } /* Literal.Number.Float */
+.highlight .mh { color: #ffb86c } /* Literal.Number.Hex */
+.highlight .mi { color: #ffb86c } /* Literal.Number.Integer */
+.highlight .mo { color: #ffb86c } /* Literal.Number.Oct */
+.highlight .sa { color: #bd93f9 } /* Literal.String.Affix */
+.highlight .sb { color: #bd93f9 } /* Literal.String.Backtick */
+.highlight .sc { color: #bd93f9 } /* Literal.String.Char */
+.highlight .dl { color: #bd93f9 } /* Literal.String.Delimiter */
+.highlight .sd { color: #bd93f9 } /* Literal.String.Doc */
+.highlight .s2 { color: #bd93f9 } /* Literal.String.Double */
+.highlight .se { color: #bd93f9 } /* Literal.String.Escape */
+.highlight .sh { color: #bd93f9 } /* Literal.String.Heredoc */
+.highlight .si { color: #bd93f9 } /* Literal.String.Interpol */
+.highlight .sx { color: #bd93f9 } /* Literal.String.Other */
+.highlight .sr { color: #bd93f9 } /* Literal.String.Regex */
+.highlight .s1 { color: #bd93f9 } /* Literal.String.Single */
+.highlight .ss { color: #bd93f9 } /* Literal.String.Symbol */
+.highlight .bp { color: #f8f8f2; font-style: italic } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #50fa7b } /* Name.Function.Magic */
+.highlight .vc { color: #8be9fd; font-style: italic } /* Name.Variable.Class */
+.highlight .vg { color: #8be9fd; font-style: italic } /* Name.Variable.Global */
+.highlight .vi { color: #8be9fd; font-style: italic } /* Name.Variable.Instance */
+.highlight .vm { color: #8be9fd; font-style: italic } /* Name.Variable.Magic */
+.highlight .il { color: #ffb86c } /* Literal.Number.Integer.Long */

--- a/emacs.css
+++ b/emacs.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #f8f8f8; }
+.highlight { background: #f8f8f8; }
 .highlight .c { color: #008800; font-style: italic } /* Comment */
 .highlight .err { border: 1px solid #FF0000 } /* Error */
 .highlight .k { color: #AA22FF; font-weight: bold } /* Keyword */

--- a/friendly.css
+++ b/friendly.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: #666666; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: #666666; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #f0f0f0; }
+.highlight { background: #f0f0f0; }
 .highlight .c { color: #60a0b0; font-style: italic } /* Comment */
 .highlight .err { border: 1px solid #FF0000 } /* Error */
 .highlight .k { color: #007020; font-weight: bold } /* Keyword */

--- a/friendly_grayscale.css
+++ b/friendly_grayscale.css
@@ -1,0 +1,74 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #f0f0f0; }
+.highlight .c { color: #959595; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #898989 } /* Error */
+.highlight .k { color: #575757; font-weight: bold } /* Keyword */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .ch { color: #959595; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #959595; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #575757 } /* Comment.Preproc */
+.highlight .cpf { color: #959595; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #959595; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #959595; background-color: #F4F4F4 } /* Comment.Special */
+.highlight .gd { color: #545454 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #898989 } /* Generic.Error */
+.highlight .gh { color: #373737; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #7D7D7D } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #7E7E7E; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #5A5A5A; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #6D6D6D } /* Generic.Traceback */
+.highlight .kc { color: #575757; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #575757; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #575757; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #575757 } /* Keyword.Pseudo */
+.highlight .kr { color: #575757; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #4F4F4F } /* Keyword.Type */
+.highlight .m { color: #888888 } /* Literal.Number */
+.highlight .s { color: #717171 } /* Literal.String */
+.highlight .na { color: #707070 } /* Name.Attribute */
+.highlight .nb { color: #575757 } /* Name.Builtin */
+.highlight .nc { color: #7E7E7E; font-weight: bold } /* Name.Class */
+.highlight .no { color: #A5A5A5 } /* Name.Constant */
+.highlight .nd { color: #555555; font-weight: bold } /* Name.Decorator */
+.highlight .ni { color: #848484; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #575757 } /* Name.Exception */
+.highlight .nf { color: #3F3F3F } /* Name.Function */
+.highlight .nl { color: #363636; font-weight: bold } /* Name.Label */
+.highlight .nn { color: #7E7E7E; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #3B3B3B; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #9A9A9A } /* Name.Variable */
+.highlight .ow { color: #575757; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #888888 } /* Literal.Number.Bin */
+.highlight .mf { color: #888888 } /* Literal.Number.Float */
+.highlight .mh { color: #888888 } /* Literal.Number.Hex */
+.highlight .mi { color: #888888 } /* Literal.Number.Integer */
+.highlight .mo { color: #888888 } /* Literal.Number.Oct */
+.highlight .sa { color: #717171 } /* Literal.String.Affix */
+.highlight .sb { color: #717171 } /* Literal.String.Backtick */
+.highlight .sc { color: #717171 } /* Literal.String.Char */
+.highlight .dl { color: #717171 } /* Literal.String.Delimiter */
+.highlight .sd { color: #717171; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #717171 } /* Literal.String.Double */
+.highlight .se { color: #717171; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #717171 } /* Literal.String.Heredoc */
+.highlight .si { color: #9F9F9F; font-style: italic } /* Literal.String.Interpol */
+.highlight .sx { color: #7E7E7E } /* Literal.String.Other */
+.highlight .sr { color: #575757 } /* Literal.String.Regex */
+.highlight .s1 { color: #717171 } /* Literal.String.Single */
+.highlight .ss { color: #676767 } /* Literal.String.Symbol */
+.highlight .bp { color: #575757 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #3F3F3F } /* Name.Function.Magic */
+.highlight .vc { color: #9A9A9A } /* Name.Variable.Class */
+.highlight .vg { color: #9A9A9A } /* Name.Variable.Global */
+.highlight .vi { color: #9A9A9A } /* Name.Variable.Instance */
+.highlight .vm { color: #9A9A9A } /* Name.Variable.Magic */
+.highlight .il { color: #888888 } /* Literal.Number.Integer.Long */

--- a/fruity.css
+++ b/fruity.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #333333 }
-.highlight  { background: #111111; color: #ffffff }
+.highlight { background: #111111; color: #ffffff }
 .highlight .c { color: #008800; font-style: italic; background-color: #0f140f } /* Comment */
 .highlight .err { color: #ffffff } /* Error */
 .highlight .esc { color: #ffffff } /* Escape */
@@ -50,6 +55,7 @@
 .highlight .nt { color: #fb660a; font-weight: bold } /* Name.Tag */
 .highlight .nv { color: #fb660a } /* Name.Variable */
 .highlight .ow { color: #ffffff } /* Operator.Word */
+.highlight .pm { color: #ffffff } /* Punctuation.Marker */
 .highlight .w { color: #888888 } /* Text.Whitespace */
 .highlight .mb { color: #0086f7; font-weight: bold } /* Literal.Number.Bin */
 .highlight .mf { color: #0086f7; font-weight: bold } /* Literal.Number.Float */

--- a/github-dark.css
+++ b/github-dark.css
@@ -1,0 +1,85 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: #6e7681; background-color: #0d1117; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: #6e7681; background-color: #0d1117; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #c9d1d9; background-color: #6e7681; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #c9d1d9; background-color: #6e7681; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #6e7681 }
+.highlight { background: #0d1117; color: #c9d1d9 }
+.highlight .c { color: #8b949e; font-style: italic } /* Comment */
+.highlight .err { color: #f85149 } /* Error */
+.highlight .esc { color: #c9d1d9 } /* Escape */
+.highlight .g { color: #c9d1d9 } /* Generic */
+.highlight .k { color: #ff7b72 } /* Keyword */
+.highlight .l { color: #a5d6ff } /* Literal */
+.highlight .n { color: #c9d1d9 } /* Name */
+.highlight .o { color: #ff7b72; font-weight: bold } /* Operator */
+.highlight .x { color: #c9d1d9 } /* Other */
+.highlight .p { color: #c9d1d9 } /* Punctuation */
+.highlight .ch { color: #8b949e; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #8b949e; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #8b949e; font-weight: bold; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #8b949e; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #8b949e; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #8b949e; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #ffa198; background-color: #490202 } /* Generic.Deleted */
+.highlight .ge { color: #c9d1d9; font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #ffa198 } /* Generic.Error */
+.highlight .gh { color: #79c0ff; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #56d364; background-color: #0f5323 } /* Generic.Inserted */
+.highlight .go { color: #8b949e } /* Generic.Output */
+.highlight .gp { color: #8b949e } /* Generic.Prompt */
+.highlight .gs { color: #c9d1d9; font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #79c0ff } /* Generic.Subheading */
+.highlight .gt { color: #ff7b72 } /* Generic.Traceback */
+.highlight .g-Underline { color: #c9d1d9; text-decoration: underline } /* Generic.Underline */
+.highlight .kc { color: #79c0ff } /* Keyword.Constant */
+.highlight .kd { color: #ff7b72 } /* Keyword.Declaration */
+.highlight .kn { color: #ff7b72 } /* Keyword.Namespace */
+.highlight .kp { color: #79c0ff } /* Keyword.Pseudo */
+.highlight .kr { color: #ff7b72 } /* Keyword.Reserved */
+.highlight .kt { color: #ff7b72 } /* Keyword.Type */
+.highlight .ld { color: #79c0ff } /* Literal.Date */
+.highlight .m { color: #a5d6ff } /* Literal.Number */
+.highlight .s { color: #a5d6ff } /* Literal.String */
+.highlight .na { color: #c9d1d9 } /* Name.Attribute */
+.highlight .nb { color: #c9d1d9 } /* Name.Builtin */
+.highlight .nc { color: #f0883e; font-weight: bold } /* Name.Class */
+.highlight .no { color: #79c0ff; font-weight: bold } /* Name.Constant */
+.highlight .nd { color: #d2a8ff; font-weight: bold } /* Name.Decorator */
+.highlight .ni { color: #ffa657 } /* Name.Entity */
+.highlight .ne { color: #f0883e; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #d2a8ff; font-weight: bold } /* Name.Function */
+.highlight .nl { color: #79c0ff; font-weight: bold } /* Name.Label */
+.highlight .nn { color: #ff7b72 } /* Name.Namespace */
+.highlight .nx { color: #c9d1d9 } /* Name.Other */
+.highlight .py { color: #79c0ff } /* Name.Property */
+.highlight .nt { color: #7ee787 } /* Name.Tag */
+.highlight .nv { color: #79c0ff } /* Name.Variable */
+.highlight .ow { color: #ff7b72; font-weight: bold } /* Operator.Word */
+.highlight .pm { color: #c9d1d9 } /* Punctuation.Marker */
+.highlight .w { color: #6e7681 } /* Text.Whitespace */
+.highlight .mb { color: #a5d6ff } /* Literal.Number.Bin */
+.highlight .mf { color: #a5d6ff } /* Literal.Number.Float */
+.highlight .mh { color: #a5d6ff } /* Literal.Number.Hex */
+.highlight .mi { color: #a5d6ff } /* Literal.Number.Integer */
+.highlight .mo { color: #a5d6ff } /* Literal.Number.Oct */
+.highlight .sa { color: #79c0ff } /* Literal.String.Affix */
+.highlight .sb { color: #a5d6ff } /* Literal.String.Backtick */
+.highlight .sc { color: #a5d6ff } /* Literal.String.Char */
+.highlight .dl { color: #79c0ff } /* Literal.String.Delimiter */
+.highlight .sd { color: #a5d6ff } /* Literal.String.Doc */
+.highlight .s2 { color: #a5d6ff } /* Literal.String.Double */
+.highlight .se { color: #79c0ff } /* Literal.String.Escape */
+.highlight .sh { color: #79c0ff } /* Literal.String.Heredoc */
+.highlight .si { color: #a5d6ff } /* Literal.String.Interpol */
+.highlight .sx { color: #a5d6ff } /* Literal.String.Other */
+.highlight .sr { color: #79c0ff } /* Literal.String.Regex */
+.highlight .s1 { color: #a5d6ff } /* Literal.String.Single */
+.highlight .ss { color: #a5d6ff } /* Literal.String.Symbol */
+.highlight .bp { color: #c9d1d9 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #d2a8ff; font-weight: bold } /* Name.Function.Magic */
+.highlight .vc { color: #79c0ff } /* Name.Variable.Class */
+.highlight .vg { color: #79c0ff } /* Name.Variable.Global */
+.highlight .vi { color: #79c0ff } /* Name.Variable.Instance */
+.highlight .vm { color: #79c0ff } /* Name.Variable.Magic */
+.highlight .il { color: #a5d6ff } /* Literal.Number.Integer.Long */

--- a/gruvbox-dark.css
+++ b/gruvbox-dark.css
@@ -1,0 +1,85 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ebdbb2 }
+.highlight { background: #282828; color: #dddddd }
+.highlight .c { color: #928374; font-style: italic } /* Comment */
+.highlight .err { color: #282828; background-color: #fb4934 } /* Error */
+.highlight .esc { color: #dddddd } /* Escape */
+.highlight .g { color: #dddddd } /* Generic */
+.highlight .k { color: #fb4934 } /* Keyword */
+.highlight .l { color: #dddddd } /* Literal */
+.highlight .n { color: #dddddd } /* Name */
+.highlight .o { color: #dddddd } /* Operator */
+.highlight .x { color: #dddddd } /* Other */
+.highlight .p { color: #dddddd } /* Punctuation */
+.highlight .ch { color: #928374; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #928374; font-style: italic } /* Comment.Multiline */
+.highlight .c-PreProc { color: #8ec07c; font-style: italic } /* Comment.PreProc */
+.highlight .cp { color: #928374; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #928374; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #928374; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #ebdbb2; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #282828; background-color: #fb4934 } /* Generic.Deleted */
+.highlight .ge { color: #dddddd; font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #fb4934 } /* Generic.Error */
+.highlight .gh { color: #ebdbb2; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #282828; background-color: #b8bb26 } /* Generic.Inserted */
+.highlight .go { color: #f2e5bc } /* Generic.Output */
+.highlight .gp { color: #a89984 } /* Generic.Prompt */
+.highlight .gs { color: #dddddd; font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #ebdbb2; text-decoration: underline } /* Generic.Subheading */
+.highlight .gt { color: #fb4934 } /* Generic.Traceback */
+.highlight .kc { color: #fb4934 } /* Keyword.Constant */
+.highlight .kd { color: #fb4934 } /* Keyword.Declaration */
+.highlight .kn { color: #fb4934 } /* Keyword.Namespace */
+.highlight .kp { color: #fb4934 } /* Keyword.Pseudo */
+.highlight .kr { color: #fb4934 } /* Keyword.Reserved */
+.highlight .kt { color: #fb4934 } /* Keyword.Type */
+.highlight .ld { color: #dddddd } /* Literal.Date */
+.highlight .m { color: #d3869b } /* Literal.Number */
+.highlight .s { color: #b8bb26 } /* Literal.String */
+.highlight .na { color: #fabd2f } /* Name.Attribute */
+.highlight .nb { color: #fe8019 } /* Name.Builtin */
+.highlight .nc { color: #8ec07c } /* Name.Class */
+.highlight .no { color: #d3869b } /* Name.Constant */
+.highlight .nd { color: #fb4934 } /* Name.Decorator */
+.highlight .ni { color: #dddddd } /* Name.Entity */
+.highlight .ne { color: #fb4934 } /* Name.Exception */
+.highlight .nf { color: #8ec07c } /* Name.Function */
+.highlight .nl { color: #dddddd } /* Name.Label */
+.highlight .nn { color: #8ec07c } /* Name.Namespace */
+.highlight .nx { color: #dddddd } /* Name.Other */
+.highlight .py { color: #dddddd } /* Name.Property */
+.highlight .nt { color: #8ec07c } /* Name.Tag */
+.highlight .nv { color: #83a598 } /* Name.Variable */
+.highlight .ow { color: #fb4934 } /* Operator.Word */
+.highlight .pm { color: #dddddd } /* Punctuation.Marker */
+.highlight .w { color: #dddddd } /* Text.Whitespace */
+.highlight .mb { color: #d3869b } /* Literal.Number.Bin */
+.highlight .mf { color: #d3869b } /* Literal.Number.Float */
+.highlight .mh { color: #d3869b } /* Literal.Number.Hex */
+.highlight .mi { color: #d3869b } /* Literal.Number.Integer */
+.highlight .mo { color: #d3869b } /* Literal.Number.Oct */
+.highlight .sa { color: #b8bb26 } /* Literal.String.Affix */
+.highlight .sb { color: #b8bb26 } /* Literal.String.Backtick */
+.highlight .sc { color: #b8bb26 } /* Literal.String.Char */
+.highlight .dl { color: #b8bb26 } /* Literal.String.Delimiter */
+.highlight .sd { color: #b8bb26 } /* Literal.String.Doc */
+.highlight .s2 { color: #b8bb26 } /* Literal.String.Double */
+.highlight .se { color: #fe8019 } /* Literal.String.Escape */
+.highlight .sh { color: #b8bb26 } /* Literal.String.Heredoc */
+.highlight .si { color: #b8bb26 } /* Literal.String.Interpol */
+.highlight .sx { color: #b8bb26 } /* Literal.String.Other */
+.highlight .sr { color: #b8bb26 } /* Literal.String.Regex */
+.highlight .s1 { color: #b8bb26 } /* Literal.String.Single */
+.highlight .ss { color: #b8bb26 } /* Literal.String.Symbol */
+.highlight .bp { color: #fe8019 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #8ec07c } /* Name.Function.Magic */
+.highlight .vc { color: #83a598 } /* Name.Variable.Class */
+.highlight .vg { color: #83a598 } /* Name.Variable.Global */
+.highlight .vi { color: #83a598 } /* Name.Variable.Instance */
+.highlight .vm { color: #83a598 } /* Name.Variable.Magic */
+.highlight .il { color: #d3869b } /* Literal.Number.Integer.Long */

--- a/gruvbox-light.css
+++ b/gruvbox-light.css
@@ -1,0 +1,71 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #3c3836 }
+.highlight { background: #fbf1c7; }
+.highlight .c { color: #928374; font-style: italic } /* Comment */
+.highlight .err { color: #fbf1c7; background-color: #9d0006 } /* Error */
+.highlight .k { color: #9d0006 } /* Keyword */
+.highlight .ch { color: #928374; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #928374; font-style: italic } /* Comment.Multiline */
+.highlight .c-PreProc { color: #427b58; font-style: italic } /* Comment.PreProc */
+.highlight .cp { color: #928374; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #928374; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #928374; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #3c3836; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #fbf1c7; background-color: #9d0006 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #9d0006 } /* Generic.Error */
+.highlight .gh { color: #3c3836; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #fbf1c7; background-color: #79740e } /* Generic.Inserted */
+.highlight .go { color: #32302f } /* Generic.Output */
+.highlight .gp { color: #7c6f64 } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #3c3836; text-decoration: underline } /* Generic.Subheading */
+.highlight .gt { color: #9d0006 } /* Generic.Traceback */
+.highlight .kc { color: #9d0006 } /* Keyword.Constant */
+.highlight .kd { color: #9d0006 } /* Keyword.Declaration */
+.highlight .kn { color: #9d0006 } /* Keyword.Namespace */
+.highlight .kp { color: #9d0006 } /* Keyword.Pseudo */
+.highlight .kr { color: #9d0006 } /* Keyword.Reserved */
+.highlight .kt { color: #9d0006 } /* Keyword.Type */
+.highlight .m { color: #8f3f71 } /* Literal.Number */
+.highlight .s { color: #79740e } /* Literal.String */
+.highlight .na { color: #b57614 } /* Name.Attribute */
+.highlight .nb { color: #af3a03 } /* Name.Builtin */
+.highlight .nc { color: #427b58 } /* Name.Class */
+.highlight .no { color: #8f3f71 } /* Name.Constant */
+.highlight .nd { color: #9d0006 } /* Name.Decorator */
+.highlight .ne { color: #9d0006 } /* Name.Exception */
+.highlight .nf { color: #427b58 } /* Name.Function */
+.highlight .nn { color: #427b58 } /* Name.Namespace */
+.highlight .nt { color: #427b58 } /* Name.Tag */
+.highlight .nv { color: #076678 } /* Name.Variable */
+.highlight .ow { color: #9d0006 } /* Operator.Word */
+.highlight .mb { color: #8f3f71 } /* Literal.Number.Bin */
+.highlight .mf { color: #8f3f71 } /* Literal.Number.Float */
+.highlight .mh { color: #8f3f71 } /* Literal.Number.Hex */
+.highlight .mi { color: #8f3f71 } /* Literal.Number.Integer */
+.highlight .mo { color: #8f3f71 } /* Literal.Number.Oct */
+.highlight .sa { color: #79740e } /* Literal.String.Affix */
+.highlight .sb { color: #79740e } /* Literal.String.Backtick */
+.highlight .sc { color: #79740e } /* Literal.String.Char */
+.highlight .dl { color: #79740e } /* Literal.String.Delimiter */
+.highlight .sd { color: #79740e } /* Literal.String.Doc */
+.highlight .s2 { color: #79740e } /* Literal.String.Double */
+.highlight .se { color: #af3a03 } /* Literal.String.Escape */
+.highlight .sh { color: #79740e } /* Literal.String.Heredoc */
+.highlight .si { color: #79740e } /* Literal.String.Interpol */
+.highlight .sx { color: #79740e } /* Literal.String.Other */
+.highlight .sr { color: #79740e } /* Literal.String.Regex */
+.highlight .s1 { color: #79740e } /* Literal.String.Single */
+.highlight .ss { color: #79740e } /* Literal.String.Symbol */
+.highlight .bp { color: #af3a03 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #427b58 } /* Name.Function.Magic */
+.highlight .vc { color: #076678 } /* Name.Variable.Class */
+.highlight .vg { color: #076678 } /* Name.Variable.Global */
+.highlight .vi { color: #076678 } /* Name.Variable.Instance */
+.highlight .vm { color: #076678 } /* Name.Variable.Magic */
+.highlight .il { color: #8f3f71 } /* Literal.Number.Integer.Long */

--- a/igor.css
+++ b/igor.css
@@ -1,0 +1,39 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; }
+.highlight .c { color: #FF0000; font-style: italic } /* Comment */
+.highlight .k { color: #0000FF } /* Keyword */
+.highlight .ch { color: #FF0000; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #FF0000; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #FF0000; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #FF0000; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #FF0000; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #FF0000; font-style: italic } /* Comment.Special */
+.highlight .kc { color: #0000FF } /* Keyword.Constant */
+.highlight .kd { color: #0000FF } /* Keyword.Declaration */
+.highlight .kn { color: #0000FF } /* Keyword.Namespace */
+.highlight .kp { color: #0000FF } /* Keyword.Pseudo */
+.highlight .kr { color: #0000FF } /* Keyword.Reserved */
+.highlight .kt { color: #0000FF } /* Keyword.Type */
+.highlight .s { color: #009C00 } /* Literal.String */
+.highlight .nc { color: #007575 } /* Name.Class */
+.highlight .nd { color: #CC00A3 } /* Name.Decorator */
+.highlight .nf { color: #C34E00 } /* Name.Function */
+.highlight .sa { color: #009C00 } /* Literal.String.Affix */
+.highlight .sb { color: #009C00 } /* Literal.String.Backtick */
+.highlight .sc { color: #009C00 } /* Literal.String.Char */
+.highlight .dl { color: #009C00 } /* Literal.String.Delimiter */
+.highlight .sd { color: #009C00 } /* Literal.String.Doc */
+.highlight .s2 { color: #009C00 } /* Literal.String.Double */
+.highlight .se { color: #009C00 } /* Literal.String.Escape */
+.highlight .sh { color: #009C00 } /* Literal.String.Heredoc */
+.highlight .si { color: #009C00 } /* Literal.String.Interpol */
+.highlight .sx { color: #009C00 } /* Literal.String.Other */
+.highlight .sr { color: #009C00 } /* Literal.String.Regex */
+.highlight .s1 { color: #009C00 } /* Literal.String.Single */
+.highlight .ss { color: #009C00 } /* Literal.String.Symbol */
+.highlight .fm { color: #C34E00 } /* Name.Function.Magic */

--- a/inkpot.css
+++ b/inkpot.css
@@ -1,0 +1,80 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #1e1e27; color: #cfbfad }
+.highlight .c { color: #cd8b00 } /* Comment */
+.highlight .err { color: #ffffff; background-color: #6e2e2e } /* Error */
+.highlight .k { color: #808bed } /* Keyword */
+.highlight .n { color: #cfbfad } /* Name */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .x { color: #cfbfad } /* Other */
+.highlight .p { color: #cfbfad } /* Punctuation */
+.highlight .ch { color: #cd8b00 } /* Comment.Hashbang */
+.highlight .cm { color: #cd8b00 } /* Comment.Multiline */
+.highlight .cp { color: #409090 } /* Comment.Preproc */
+.highlight .cpf { color: #ffcd8b; background-color: #404040 } /* Comment.PreprocFile */
+.highlight .c1 { color: #cd8b00 } /* Comment.Single */
+.highlight .cs { color: #808bed } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #0044DD } /* Generic.Traceback */
+.highlight .kc { color: #808bed } /* Keyword.Constant */
+.highlight .kd { color: #808bed } /* Keyword.Declaration */
+.highlight .kn { color: #808bed } /* Keyword.Namespace */
+.highlight .kp { color: #808bed } /* Keyword.Pseudo */
+.highlight .kr { color: #808bed } /* Keyword.Reserved */
+.highlight .kt { color: #ff8bff } /* Keyword.Type */
+.highlight .m { color: #f0ad6d } /* Literal.Number */
+.highlight .s { color: #ffcd8b; background-color: #404040 } /* Literal.String */
+.highlight .na { color: #cfbfad } /* Name.Attribute */
+.highlight .nb { color: #808bed } /* Name.Builtin */
+.highlight .nc { color: #ff8bff } /* Name.Class */
+.highlight .no { color: #409090 } /* Name.Constant */
+.highlight .nd { color: #409090 } /* Name.Decorator */
+.highlight .ni { color: #cfbfad } /* Name.Entity */
+.highlight .ne { color: #ff0000 } /* Name.Exception */
+.highlight .nf { color: #c080d0 } /* Name.Function */
+.highlight .nl { color: #808bed } /* Name.Label */
+.highlight .nn { color: #ff0000 } /* Name.Namespace */
+.highlight .nx { color: #cfbfad } /* Name.Other */
+.highlight .py { color: #cfbfad } /* Name.Property */
+.highlight .nt { color: #cfbfad } /* Name.Tag */
+.highlight .nv { color: #cfbfad } /* Name.Variable */
+.highlight .ow { color: #666666 } /* Operator.Word */
+.highlight .pm { color: #cfbfad } /* Punctuation.Marker */
+.highlight .w { color: #434357 } /* Text.Whitespace */
+.highlight .mb { color: #f0ad6d } /* Literal.Number.Bin */
+.highlight .mf { color: #f0ad6d } /* Literal.Number.Float */
+.highlight .mh { color: #f0ad6d } /* Literal.Number.Hex */
+.highlight .mi { color: #f0ad6d } /* Literal.Number.Integer */
+.highlight .mo { color: #f0ad6d } /* Literal.Number.Oct */
+.highlight .sa { color: #ffcd8b; background-color: #404040 } /* Literal.String.Affix */
+.highlight .sb { color: #ffcd8b; background-color: #404040 } /* Literal.String.Backtick */
+.highlight .sc { color: #ffcd8b; background-color: #404040 } /* Literal.String.Char */
+.highlight .dl { color: #ffcd8b; background-color: #404040 } /* Literal.String.Delimiter */
+.highlight .sd { color: #808bed; background-color: #404040 } /* Literal.String.Doc */
+.highlight .s2 { color: #ffcd8b; background-color: #404040 } /* Literal.String.Double */
+.highlight .se { color: #ffcd8b; background-color: #404040 } /* Literal.String.Escape */
+.highlight .sh { color: #ffcd8b; background-color: #404040 } /* Literal.String.Heredoc */
+.highlight .si { color: #ffcd8b; background-color: #404040 } /* Literal.String.Interpol */
+.highlight .sx { color: #ffcd8b; background-color: #404040 } /* Literal.String.Other */
+.highlight .sr { color: #ffcd8b; background-color: #404040 } /* Literal.String.Regex */
+.highlight .s1 { color: #ffcd8b; background-color: #404040 } /* Literal.String.Single */
+.highlight .ss { color: #ffcd8b; background-color: #404040 } /* Literal.String.Symbol */
+.highlight .bp { color: #ffff00 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #c080d0 } /* Name.Function.Magic */
+.highlight .vc { color: #cfbfad } /* Name.Variable.Class */
+.highlight .vg { color: #cfbfad } /* Name.Variable.Global */
+.highlight .vi { color: #cfbfad } /* Name.Variable.Instance */
+.highlight .vm { color: #cfbfad } /* Name.Variable.Magic */
+.highlight .il { color: #f0ad6d } /* Literal.Number.Integer.Long */

--- a/lilypond.css
+++ b/lilypond.css
@@ -1,0 +1,61 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; }
+.highlight .-ChordModifier { color: #976806 } /* ChordModifier */
+.highlight .c { color: #A3AAB2; font-style: italic } /* Comment */
+.highlight .k { font-weight: bold } /* Keyword */
+.highlight .ch { color: #A3AAB2; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #A3AAB2; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #A3AAB2; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #A3AAB2; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #A3AAB2; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #A3AAB2; font-style: italic } /* Comment.Special */
+.highlight .kc { font-weight: bold } /* Keyword.Constant */
+.highlight .kd { font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { font-weight: bold } /* Keyword.Pseudo */
+.highlight .kr { font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { font-weight: bold } /* Keyword.Type */
+.highlight .m { color: #976806 } /* Literal.Number */
+.highlight .s { color: #AB0909 } /* Literal.String */
+.highlight .n-BackslashReference { color: #08547A } /* Name.BackslashReference */
+.highlight .n-Lvalue { color: #08547A } /* Name.Lvalue */
+.highlight .mb { color: #976806 } /* Literal.Number.Bin */
+.highlight .mf { color: #976806 } /* Literal.Number.Float */
+.highlight .mh { color: #976806 } /* Literal.Number.Hex */
+.highlight .mi { color: #976806 } /* Literal.Number.Integer */
+.highlight .mo { color: #976806 } /* Literal.Number.Oct */
+.highlight .sa { color: #AB0909 } /* Literal.String.Affix */
+.highlight .sb { color: #AB0909 } /* Literal.String.Backtick */
+.highlight .sc { color: #AB0909 } /* Literal.String.Char */
+.highlight .dl { color: #AB0909 } /* Literal.String.Delimiter */
+.highlight .sd { color: #AB0909 } /* Literal.String.Doc */
+.highlight .s2 { color: #AB0909 } /* Literal.String.Double */
+.highlight .se { color: #C46C6C } /* Literal.String.Escape */
+.highlight .sh { color: #AB0909 } /* Literal.String.Heredoc */
+.highlight .si { color: #AB0909 } /* Literal.String.Interpol */
+.highlight .sx { color: #AB0909 } /* Literal.String.Other */
+.highlight .sr { color: #AB0909 } /* Literal.String.Regex */
+.highlight .s1 { color: #AB0909 } /* Literal.String.Single */
+.highlight .nb-Articulation { color: #68175A } /* Name.Builtin.Articulation */
+.highlight .nb-Clef { color: #08547A; font-weight: bold } /* Name.Builtin.Clef */
+.highlight .nb-Context { color: #038B8B; font-weight: bold } /* Name.Builtin.Context */
+.highlight .nb-ContextProperty { color: #038B8B } /* Name.Builtin.ContextProperty */
+.highlight .nb-Dynamic { color: #68175A } /* Name.Builtin.Dynamic */
+.highlight .nb-Grob { color: #0C7441; font-weight: bold } /* Name.Builtin.Grob */
+.highlight .nb-GrobProperty { color: #0C7441 } /* Name.Builtin.GrobProperty */
+.highlight .nb-HeaderVariable { color: #6C5A05; font-weight: bold } /* Name.Builtin.HeaderVariable */
+.highlight .nb-MarkupCommand { color: #831E71; font-weight: bold } /* Name.Builtin.MarkupCommand */
+.highlight .nb-MusicCommand { color: #08547A; font-weight: bold } /* Name.Builtin.MusicCommand */
+.highlight .nb-MusicFunction { color: #08547A; font-weight: bold } /* Name.Builtin.MusicFunction */
+.highlight .nb-PaperVariable { color: #6C5A05; font-weight: bold } /* Name.Builtin.PaperVariable */
+.highlight .nb-RepeatType { color: #08547A } /* Name.Builtin.RepeatType */
+.highlight .nb-Scale { color: #08547A; font-weight: bold } /* Name.Builtin.Scale */
+.highlight .nb-SchemeBuiltin { font-weight: bold } /* Name.Builtin.SchemeBuiltin */
+.highlight .nb-SchemeFunction { color: #A83401; font-weight: bold } /* Name.Builtin.SchemeFunction */
+.highlight .nb-Translator { color: #6200A4; font-weight: bold } /* Name.Builtin.Translator */
+.highlight .il { color: #976806 } /* Literal.Number.Integer.Long */

--- a/lovelace.css
+++ b/lovelace.css
@@ -1,0 +1,76 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; }
+.highlight .c { color: #888888; font-style: italic } /* Comment */
+.highlight .err { background-color: #a848a8 } /* Error */
+.highlight .k { color: #2838b0 } /* Keyword */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .p { color: #888888 } /* Punctuation */
+.highlight .ch { color: #287088; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #888888; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #289870 } /* Comment.Preproc */
+.highlight .cpf { color: #888888; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #888888; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #888888; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #c02828 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #c02828 } /* Generic.Error */
+.highlight .gh { color: #666666 } /* Generic.Heading */
+.highlight .gi { color: #388038 } /* Generic.Inserted */
+.highlight .go { color: #666666 } /* Generic.Output */
+.highlight .gp { color: #444444 } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #444444 } /* Generic.Subheading */
+.highlight .gt { color: #2838b0 } /* Generic.Traceback */
+.highlight .kc { color: #444444; font-style: italic } /* Keyword.Constant */
+.highlight .kd { color: #2838b0; font-style: italic } /* Keyword.Declaration */
+.highlight .kn { color: #2838b0 } /* Keyword.Namespace */
+.highlight .kp { color: #2838b0 } /* Keyword.Pseudo */
+.highlight .kr { color: #2838b0 } /* Keyword.Reserved */
+.highlight .kt { color: #2838b0; font-style: italic } /* Keyword.Type */
+.highlight .m { color: #444444 } /* Literal.Number */
+.highlight .s { color: #b83838 } /* Literal.String */
+.highlight .na { color: #388038 } /* Name.Attribute */
+.highlight .nb { color: #388038 } /* Name.Builtin */
+.highlight .nc { color: #287088 } /* Name.Class */
+.highlight .no { color: #b85820 } /* Name.Constant */
+.highlight .nd { color: #287088 } /* Name.Decorator */
+.highlight .ni { color: #709030 } /* Name.Entity */
+.highlight .ne { color: #908828 } /* Name.Exception */
+.highlight .nf { color: #785840 } /* Name.Function */
+.highlight .nl { color: #289870 } /* Name.Label */
+.highlight .nn { color: #289870 } /* Name.Namespace */
+.highlight .nt { color: #2838b0 } /* Name.Tag */
+.highlight .nv { color: #b04040 } /* Name.Variable */
+.highlight .ow { color: #a848a8 } /* Operator.Word */
+.highlight .pm { color: #888888 } /* Punctuation.Marker */
+.highlight .w { color: #a89028 } /* Text.Whitespace */
+.highlight .mb { color: #444444 } /* Literal.Number.Bin */
+.highlight .mf { color: #444444 } /* Literal.Number.Float */
+.highlight .mh { color: #444444 } /* Literal.Number.Hex */
+.highlight .mi { color: #444444 } /* Literal.Number.Integer */
+.highlight .mo { color: #444444 } /* Literal.Number.Oct */
+.highlight .sa { color: #444444 } /* Literal.String.Affix */
+.highlight .sb { color: #b83838 } /* Literal.String.Backtick */
+.highlight .sc { color: #a848a8 } /* Literal.String.Char */
+.highlight .dl { color: #b85820 } /* Literal.String.Delimiter */
+.highlight .sd { color: #b85820; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #b83838 } /* Literal.String.Double */
+.highlight .se { color: #709030 } /* Literal.String.Escape */
+.highlight .sh { color: #b83838 } /* Literal.String.Heredoc */
+.highlight .si { color: #b83838; text-decoration: underline } /* Literal.String.Interpol */
+.highlight .sx { color: #a848a8 } /* Literal.String.Other */
+.highlight .sr { color: #a848a8 } /* Literal.String.Regex */
+.highlight .s1 { color: #b83838 } /* Literal.String.Single */
+.highlight .ss { color: #b83838 } /* Literal.String.Symbol */
+.highlight .bp { color: #388038; font-style: italic } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #b85820 } /* Name.Function.Magic */
+.highlight .vc { color: #b04040 } /* Name.Variable.Class */
+.highlight .vg { color: #908828 } /* Name.Variable.Global */
+.highlight .vi { color: #b04040 } /* Name.Variable.Instance */
+.highlight .vm { color: #b85820 } /* Name.Variable.Magic */
+.highlight .il { color: #444444 } /* Literal.Number.Integer.Long */

--- a/makefile
+++ b/makefile
@@ -5,25 +5,7 @@
 # (pygmentize documentation is pretty scattered and confusing, but the "-a" will add other classes
 # to the output)
 
-
-STYLES = autumn
-STYLES += borland
-STYLES += bw
-STYLES += colorful
-STYLES += default
-STYLES += emacs
-STYLES += friendly
-STYLES += fruity
-STYLES += manni
-STYLES += monokai
-STYLES += murphy
-STYLES += native
-STYLES += pastie
-STYLES += perldoc
-STYLES += tango
-STYLES += trac
-STYLES += vim
-STYLES += vs
+STYLES := $(shell python3 -c "from pygments.styles import get_all_styles; print(\"\n\".join(list(get_all_styles())))")
 
 # a recursively-expanding variable, so that its value contains an actual function call to be
 # re-expanded under the control of foreach

--- a/manni.css
+++ b/manni.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #f0f3f3; }
+.highlight { background: #f0f3f3; }
 .highlight .c { color: #0099FF; font-style: italic } /* Comment */
 .highlight .err { color: #AA0000; background-color: #FFAAAA } /* Error */
 .highlight .k { color: #006699; font-weight: bold } /* Keyword */

--- a/material.css
+++ b/material.css
@@ -1,0 +1,83 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: #37474F; background-color: #263238; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: #37474F; background-color: #263238; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #607A86; background-color: #263238; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #607A86; background-color: #263238; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #2C3B41 }
+.highlight { background: #263238; color: #EEFFFF }
+.highlight .c { color: #546E7A; font-style: italic } /* Comment */
+.highlight .err { color: #FF5370 } /* Error */
+.highlight .esc { color: #89DDFF } /* Escape */
+.highlight .g { color: #EEFFFF } /* Generic */
+.highlight .k { color: #BB80B3 } /* Keyword */
+.highlight .l { color: #C3E88D } /* Literal */
+.highlight .n { color: #EEFFFF } /* Name */
+.highlight .o { color: #89DDFF } /* Operator */
+.highlight .p { color: #89DDFF } /* Punctuation */
+.highlight .ch { color: #546E7A; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #546E7A; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #546E7A; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #546E7A; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #546E7A; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #546E7A; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #FF5370 } /* Generic.Deleted */
+.highlight .ge { color: #89DDFF } /* Generic.Emph */
+.highlight .gr { color: #FF5370 } /* Generic.Error */
+.highlight .gh { color: #C3E88D } /* Generic.Heading */
+.highlight .gi { color: #C3E88D } /* Generic.Inserted */
+.highlight .go { color: #546E7A } /* Generic.Output */
+.highlight .gp { color: #FFCB6B } /* Generic.Prompt */
+.highlight .gs { color: #FF5370 } /* Generic.Strong */
+.highlight .gu { color: #89DDFF } /* Generic.Subheading */
+.highlight .gt { color: #FF5370 } /* Generic.Traceback */
+.highlight .kc { color: #89DDFF } /* Keyword.Constant */
+.highlight .kd { color: #BB80B3 } /* Keyword.Declaration */
+.highlight .kn { color: #89DDFF; font-style: italic } /* Keyword.Namespace */
+.highlight .kp { color: #89DDFF } /* Keyword.Pseudo */
+.highlight .kr { color: #BB80B3 } /* Keyword.Reserved */
+.highlight .kt { color: #BB80B3 } /* Keyword.Type */
+.highlight .ld { color: #C3E88D } /* Literal.Date */
+.highlight .m { color: #F78C6C } /* Literal.Number */
+.highlight .s { color: #C3E88D } /* Literal.String */
+.highlight .na { color: #BB80B3 } /* Name.Attribute */
+.highlight .nb { color: #82AAFF } /* Name.Builtin */
+.highlight .nc { color: #FFCB6B } /* Name.Class */
+.highlight .no { color: #EEFFFF } /* Name.Constant */
+.highlight .nd { color: #82AAFF } /* Name.Decorator */
+.highlight .ni { color: #89DDFF } /* Name.Entity */
+.highlight .ne { color: #FFCB6B } /* Name.Exception */
+.highlight .nf { color: #82AAFF } /* Name.Function */
+.highlight .nl { color: #82AAFF } /* Name.Label */
+.highlight .nn { color: #FFCB6B } /* Name.Namespace */
+.highlight .nx { color: #EEFFFF } /* Name.Other */
+.highlight .py { color: #FFCB6B } /* Name.Property */
+.highlight .nt { color: #FF5370 } /* Name.Tag */
+.highlight .nv { color: #89DDFF } /* Name.Variable */
+.highlight .ow { color: #89DDFF; font-style: italic } /* Operator.Word */
+.highlight .pm { color: #89DDFF } /* Punctuation.Marker */
+.highlight .w { color: #EEFFFF } /* Text.Whitespace */
+.highlight .mb { color: #F78C6C } /* Literal.Number.Bin */
+.highlight .mf { color: #F78C6C } /* Literal.Number.Float */
+.highlight .mh { color: #F78C6C } /* Literal.Number.Hex */
+.highlight .mi { color: #F78C6C } /* Literal.Number.Integer */
+.highlight .mo { color: #F78C6C } /* Literal.Number.Oct */
+.highlight .sa { color: #BB80B3 } /* Literal.String.Affix */
+.highlight .sb { color: #C3E88D } /* Literal.String.Backtick */
+.highlight .sc { color: #C3E88D } /* Literal.String.Char */
+.highlight .dl { color: #EEFFFF } /* Literal.String.Delimiter */
+.highlight .sd { color: #546E7A; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #C3E88D } /* Literal.String.Double */
+.highlight .se { color: #EEFFFF } /* Literal.String.Escape */
+.highlight .sh { color: #C3E88D } /* Literal.String.Heredoc */
+.highlight .si { color: #89DDFF } /* Literal.String.Interpol */
+.highlight .sx { color: #C3E88D } /* Literal.String.Other */
+.highlight .sr { color: #89DDFF } /* Literal.String.Regex */
+.highlight .s1 { color: #C3E88D } /* Literal.String.Single */
+.highlight .ss { color: #89DDFF } /* Literal.String.Symbol */
+.highlight .bp { color: #89DDFF } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #82AAFF } /* Name.Function.Magic */
+.highlight .vc { color: #89DDFF } /* Name.Variable.Class */
+.highlight .vg { color: #89DDFF } /* Name.Variable.Global */
+.highlight .vi { color: #89DDFF } /* Name.Variable.Instance */
+.highlight .vm { color: #82AAFF } /* Name.Variable.Magic */
+.highlight .il { color: #F78C6C } /* Literal.Number.Integer.Long */

--- a/monokai.css
+++ b/monokai.css
@@ -1,11 +1,19 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #49483e }
-.highlight  { background: #272822; color: #f8f8f2 }
+.highlight { background: #272822; color: #f8f8f2 }
 .highlight .c { color: #75715e } /* Comment */
 .highlight .err { color: #960050; background-color: #1e0010 } /* Error */
+.highlight .esc { color: #f8f8f2 } /* Escape */
+.highlight .g { color: #f8f8f2 } /* Generic */
 .highlight .k { color: #66d9ef } /* Keyword */
 .highlight .l { color: #ae81ff } /* Literal */
 .highlight .n { color: #f8f8f2 } /* Name */
 .highlight .o { color: #f92672 } /* Operator */
+.highlight .x { color: #f8f8f2 } /* Other */
 .highlight .p { color: #f8f8f2 } /* Punctuation */
 .highlight .ch { color: #75715e } /* Comment.Hashbang */
 .highlight .cm { color: #75715e } /* Comment.Multiline */
@@ -14,10 +22,15 @@
 .highlight .c1 { color: #75715e } /* Comment.Single */
 .highlight .cs { color: #75715e } /* Comment.Special */
 .highlight .gd { color: #f92672 } /* Generic.Deleted */
-.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .ge { color: #f8f8f2; font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #f8f8f2 } /* Generic.Error */
+.highlight .gh { color: #f8f8f2 } /* Generic.Heading */
 .highlight .gi { color: #a6e22e } /* Generic.Inserted */
-.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .go { color: #66d9ef } /* Generic.Output */
+.highlight .gp { color: #f92672; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { color: #f8f8f2; font-weight: bold } /* Generic.Strong */
 .highlight .gu { color: #75715e } /* Generic.Subheading */
+.highlight .gt { color: #f8f8f2 } /* Generic.Traceback */
 .highlight .kc { color: #66d9ef } /* Keyword.Constant */
 .highlight .kd { color: #66d9ef } /* Keyword.Declaration */
 .highlight .kn { color: #f92672 } /* Keyword.Namespace */
@@ -42,6 +55,7 @@
 .highlight .nt { color: #f92672 } /* Name.Tag */
 .highlight .nv { color: #f8f8f2 } /* Name.Variable */
 .highlight .ow { color: #f92672 } /* Operator.Word */
+.highlight .pm { color: #f8f8f2 } /* Punctuation.Marker */
 .highlight .w { color: #f8f8f2 } /* Text.Whitespace */
 .highlight .mb { color: #ae81ff } /* Literal.Number.Bin */
 .highlight .mf { color: #ae81ff } /* Literal.Number.Float */

--- a/murphy.css
+++ b/murphy.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #ffffff; }
+.highlight { background: #ffffff; }
 .highlight .c { color: #666666; font-style: italic } /* Comment */
 .highlight .err { color: #FF0000; background-color: #FFAAAA } /* Error */
 .highlight .k { color: #228899; font-weight: bold } /* Keyword */

--- a/native.css
+++ b/native.css
@@ -1,20 +1,25 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: #aaaaaa; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: #aaaaaa; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #404040 }
-.highlight  { background: #202020; color: #d0d0d0 }
-.highlight .c { color: #999999; font-style: italic } /* Comment */
+.highlight { background: #202020; color: #d0d0d0 }
+.highlight .c { color: #ababab; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .esc { color: #d0d0d0 } /* Escape */
 .highlight .g { color: #d0d0d0 } /* Generic */
-.highlight .k { color: #6ab825; font-weight: bold } /* Keyword */
+.highlight .k { color: #6ebf26; font-weight: bold } /* Keyword */
 .highlight .l { color: #d0d0d0 } /* Literal */
 .highlight .n { color: #d0d0d0 } /* Name */
 .highlight .o { color: #d0d0d0 } /* Operator */
 .highlight .x { color: #d0d0d0 } /* Other */
 .highlight .p { color: #d0d0d0 } /* Punctuation */
-.highlight .ch { color: #999999; font-style: italic } /* Comment.Hashbang */
-.highlight .cm { color: #999999; font-style: italic } /* Comment.Multiline */
+.highlight .ch { color: #ababab; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #ababab; font-style: italic } /* Comment.Multiline */
 .highlight .cp { color: #cd2828; font-weight: bold } /* Comment.Preproc */
-.highlight .cpf { color: #999999; font-style: italic } /* Comment.PreprocFile */
-.highlight .c1 { color: #999999; font-style: italic } /* Comment.Single */
+.highlight .cpf { color: #ababab; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #ababab; font-style: italic } /* Comment.Single */
 .highlight .cs { color: #e50808; font-weight: bold; background-color: #520000 } /* Comment.Special */
 .highlight .gd { color: #d22323 } /* Generic.Deleted */
 .highlight .ge { color: #d0d0d0; font-style: italic } /* Generic.Emph */
@@ -26,36 +31,37 @@
 .highlight .gs { color: #d0d0d0; font-weight: bold } /* Generic.Strong */
 .highlight .gu { color: #ffffff; text-decoration: underline } /* Generic.Subheading */
 .highlight .gt { color: #d22323 } /* Generic.Traceback */
-.highlight .kc { color: #6ab825; font-weight: bold } /* Keyword.Constant */
-.highlight .kd { color: #6ab825; font-weight: bold } /* Keyword.Declaration */
-.highlight .kn { color: #6ab825; font-weight: bold } /* Keyword.Namespace */
-.highlight .kp { color: #6ab825 } /* Keyword.Pseudo */
-.highlight .kr { color: #6ab825; font-weight: bold } /* Keyword.Reserved */
-.highlight .kt { color: #6ab825; font-weight: bold } /* Keyword.Type */
+.highlight .kc { color: #6ebf26; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #6ebf26; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #6ebf26; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #6ebf26 } /* Keyword.Pseudo */
+.highlight .kr { color: #6ebf26; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #6ebf26; font-weight: bold } /* Keyword.Type */
 .highlight .ld { color: #d0d0d0 } /* Literal.Date */
-.highlight .m { color: #3677a9 } /* Literal.Number */
+.highlight .m { color: #51b2fd } /* Literal.Number */
 .highlight .s { color: #ed9d13 } /* Literal.String */
 .highlight .na { color: #bbbbbb } /* Name.Attribute */
-.highlight .nb { color: #24909d } /* Name.Builtin */
-.highlight .nc { color: #447fcf; text-decoration: underline } /* Name.Class */
+.highlight .nb { color: #2fbccd } /* Name.Builtin */
+.highlight .nc { color: #71adff; text-decoration: underline } /* Name.Class */
 .highlight .no { color: #40ffff } /* Name.Constant */
 .highlight .nd { color: #ffa500 } /* Name.Decorator */
 .highlight .ni { color: #d0d0d0 } /* Name.Entity */
 .highlight .ne { color: #bbbbbb } /* Name.Exception */
-.highlight .nf { color: #447fcf } /* Name.Function */
+.highlight .nf { color: #71adff } /* Name.Function */
 .highlight .nl { color: #d0d0d0 } /* Name.Label */
-.highlight .nn { color: #447fcf; text-decoration: underline } /* Name.Namespace */
+.highlight .nn { color: #71adff; text-decoration: underline } /* Name.Namespace */
 .highlight .nx { color: #d0d0d0 } /* Name.Other */
 .highlight .py { color: #d0d0d0 } /* Name.Property */
-.highlight .nt { color: #6ab825; font-weight: bold } /* Name.Tag */
+.highlight .nt { color: #6ebf26; font-weight: bold } /* Name.Tag */
 .highlight .nv { color: #40ffff } /* Name.Variable */
-.highlight .ow { color: #6ab825; font-weight: bold } /* Operator.Word */
+.highlight .ow { color: #6ebf26; font-weight: bold } /* Operator.Word */
+.highlight .pm { color: #d0d0d0 } /* Punctuation.Marker */
 .highlight .w { color: #666666 } /* Text.Whitespace */
-.highlight .mb { color: #3677a9 } /* Literal.Number.Bin */
-.highlight .mf { color: #3677a9 } /* Literal.Number.Float */
-.highlight .mh { color: #3677a9 } /* Literal.Number.Hex */
-.highlight .mi { color: #3677a9 } /* Literal.Number.Integer */
-.highlight .mo { color: #3677a9 } /* Literal.Number.Oct */
+.highlight .mb { color: #51b2fd } /* Literal.Number.Bin */
+.highlight .mf { color: #51b2fd } /* Literal.Number.Float */
+.highlight .mh { color: #51b2fd } /* Literal.Number.Hex */
+.highlight .mi { color: #51b2fd } /* Literal.Number.Integer */
+.highlight .mo { color: #51b2fd } /* Literal.Number.Oct */
 .highlight .sa { color: #ed9d13 } /* Literal.String.Affix */
 .highlight .sb { color: #ed9d13 } /* Literal.String.Backtick */
 .highlight .sc { color: #ed9d13 } /* Literal.String.Char */
@@ -69,10 +75,10 @@
 .highlight .sr { color: #ed9d13 } /* Literal.String.Regex */
 .highlight .s1 { color: #ed9d13 } /* Literal.String.Single */
 .highlight .ss { color: #ed9d13 } /* Literal.String.Symbol */
-.highlight .bp { color: #24909d } /* Name.Builtin.Pseudo */
-.highlight .fm { color: #447fcf } /* Name.Function.Magic */
+.highlight .bp { color: #2fbccd } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #71adff } /* Name.Function.Magic */
 .highlight .vc { color: #40ffff } /* Name.Variable.Class */
 .highlight .vg { color: #40ffff } /* Name.Variable.Global */
 .highlight .vi { color: #40ffff } /* Name.Variable.Instance */
 .highlight .vm { color: #40ffff } /* Name.Variable.Magic */
-.highlight .il { color: #3677a9 } /* Literal.Number.Integer.Long */
+.highlight .il { color: #51b2fd } /* Literal.Number.Integer.Long */

--- a/nord-darker.css
+++ b/nord-darker.css
@@ -1,0 +1,84 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: #D8DEE9; background-color: #242933; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: #D8DEE9; background-color: #242933; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #242933; background-color: #D8DEE9; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #242933; background-color: #D8DEE9; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #3B4252 }
+.highlight { background: #242933; color: #d8dee9 }
+.highlight .c { color: #616e87; font-style: italic } /* Comment */
+.highlight .err { color: #bf616a } /* Error */
+.highlight .esc { color: #d8dee9 } /* Escape */
+.highlight .g { color: #d8dee9 } /* Generic */
+.highlight .k { color: #81a1c1; font-weight: bold } /* Keyword */
+.highlight .l { color: #d8dee9 } /* Literal */
+.highlight .n { color: #d8dee9 } /* Name */
+.highlight .o { color: #81a1c1; font-weight: bold } /* Operator */
+.highlight .x { color: #d8dee9 } /* Other */
+.highlight .p { color: #eceff4 } /* Punctuation */
+.highlight .ch { color: #616e87; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #616e87; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #5e81ac; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #616e87; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #616e87; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #616e87; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #bf616a } /* Generic.Deleted */
+.highlight .ge { color: #d8dee9; font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #bf616a } /* Generic.Error */
+.highlight .gh { color: #88c0d0; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #a3be8c } /* Generic.Inserted */
+.highlight .go { color: #d8dee9 } /* Generic.Output */
+.highlight .gp { color: #616e88; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { color: #d8dee9; font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #88c0d0; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #bf616a } /* Generic.Traceback */
+.highlight .kc { color: #81a1c1; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #81a1c1; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #81a1c1; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #81a1c1 } /* Keyword.Pseudo */
+.highlight .kr { color: #81a1c1; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #81a1c1 } /* Keyword.Type */
+.highlight .ld { color: #d8dee9 } /* Literal.Date */
+.highlight .m { color: #b48ead } /* Literal.Number */
+.highlight .s { color: #a3be8c } /* Literal.String */
+.highlight .na { color: #8fbcbb } /* Name.Attribute */
+.highlight .nb { color: #81a1c1 } /* Name.Builtin */
+.highlight .nc { color: #8fbcbb } /* Name.Class */
+.highlight .no { color: #8fbcbb } /* Name.Constant */
+.highlight .nd { color: #d08770 } /* Name.Decorator */
+.highlight .ni { color: #d08770 } /* Name.Entity */
+.highlight .ne { color: #bf616a } /* Name.Exception */
+.highlight .nf { color: #88c0d0 } /* Name.Function */
+.highlight .nl { color: #d8dee9 } /* Name.Label */
+.highlight .nn { color: #8fbcbb } /* Name.Namespace */
+.highlight .nx { color: #d8dee9 } /* Name.Other */
+.highlight .py { color: #d8dee9 } /* Name.Property */
+.highlight .nt { color: #81a1c1 } /* Name.Tag */
+.highlight .nv { color: #d8dee9 } /* Name.Variable */
+.highlight .ow { color: #81a1c1; font-weight: bold } /* Operator.Word */
+.highlight .pm { color: #eceff4 } /* Punctuation.Marker */
+.highlight .w { color: #d8dee9 } /* Text.Whitespace */
+.highlight .mb { color: #b48ead } /* Literal.Number.Bin */
+.highlight .mf { color: #b48ead } /* Literal.Number.Float */
+.highlight .mh { color: #b48ead } /* Literal.Number.Hex */
+.highlight .mi { color: #b48ead } /* Literal.Number.Integer */
+.highlight .mo { color: #b48ead } /* Literal.Number.Oct */
+.highlight .sa { color: #a3be8c } /* Literal.String.Affix */
+.highlight .sb { color: #a3be8c } /* Literal.String.Backtick */
+.highlight .sc { color: #a3be8c } /* Literal.String.Char */
+.highlight .dl { color: #a3be8c } /* Literal.String.Delimiter */
+.highlight .sd { color: #616e87 } /* Literal.String.Doc */
+.highlight .s2 { color: #a3be8c } /* Literal.String.Double */
+.highlight .se { color: #ebcb8b } /* Literal.String.Escape */
+.highlight .sh { color: #a3be8c } /* Literal.String.Heredoc */
+.highlight .si { color: #a3be8c } /* Literal.String.Interpol */
+.highlight .sx { color: #a3be8c } /* Literal.String.Other */
+.highlight .sr { color: #ebcb8b } /* Literal.String.Regex */
+.highlight .s1 { color: #a3be8c } /* Literal.String.Single */
+.highlight .ss { color: #a3be8c } /* Literal.String.Symbol */
+.highlight .bp { color: #81a1c1 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #88c0d0 } /* Name.Function.Magic */
+.highlight .vc { color: #d8dee9 } /* Name.Variable.Class */
+.highlight .vg { color: #d8dee9 } /* Name.Variable.Global */
+.highlight .vi { color: #d8dee9 } /* Name.Variable.Instance */
+.highlight .vm { color: #d8dee9 } /* Name.Variable.Magic */
+.highlight .il { color: #b48ead } /* Literal.Number.Integer.Long */

--- a/nord.css
+++ b/nord.css
@@ -1,0 +1,84 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: #D8DEE9; background-color: #242933; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: #D8DEE9; background-color: #242933; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #242933; background-color: #D8DEE9; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #242933; background-color: #D8DEE9; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #3B4252 }
+.highlight { background: #2E3440; color: #d8dee9 }
+.highlight .c { color: #616e87; font-style: italic } /* Comment */
+.highlight .err { color: #bf616a } /* Error */
+.highlight .esc { color: #d8dee9 } /* Escape */
+.highlight .g { color: #d8dee9 } /* Generic */
+.highlight .k { color: #81a1c1; font-weight: bold } /* Keyword */
+.highlight .l { color: #d8dee9 } /* Literal */
+.highlight .n { color: #d8dee9 } /* Name */
+.highlight .o { color: #81a1c1; font-weight: bold } /* Operator */
+.highlight .x { color: #d8dee9 } /* Other */
+.highlight .p { color: #eceff4 } /* Punctuation */
+.highlight .ch { color: #616e87; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #616e87; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #5e81ac; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #616e87; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #616e87; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #616e87; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #bf616a } /* Generic.Deleted */
+.highlight .ge { color: #d8dee9; font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #bf616a } /* Generic.Error */
+.highlight .gh { color: #88c0d0; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #a3be8c } /* Generic.Inserted */
+.highlight .go { color: #d8dee9 } /* Generic.Output */
+.highlight .gp { color: #616e88; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { color: #d8dee9; font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #88c0d0; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #bf616a } /* Generic.Traceback */
+.highlight .kc { color: #81a1c1; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #81a1c1; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #81a1c1; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #81a1c1 } /* Keyword.Pseudo */
+.highlight .kr { color: #81a1c1; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #81a1c1 } /* Keyword.Type */
+.highlight .ld { color: #d8dee9 } /* Literal.Date */
+.highlight .m { color: #b48ead } /* Literal.Number */
+.highlight .s { color: #a3be8c } /* Literal.String */
+.highlight .na { color: #8fbcbb } /* Name.Attribute */
+.highlight .nb { color: #81a1c1 } /* Name.Builtin */
+.highlight .nc { color: #8fbcbb } /* Name.Class */
+.highlight .no { color: #8fbcbb } /* Name.Constant */
+.highlight .nd { color: #d08770 } /* Name.Decorator */
+.highlight .ni { color: #d08770 } /* Name.Entity */
+.highlight .ne { color: #bf616a } /* Name.Exception */
+.highlight .nf { color: #88c0d0 } /* Name.Function */
+.highlight .nl { color: #d8dee9 } /* Name.Label */
+.highlight .nn { color: #8fbcbb } /* Name.Namespace */
+.highlight .nx { color: #d8dee9 } /* Name.Other */
+.highlight .py { color: #d8dee9 } /* Name.Property */
+.highlight .nt { color: #81a1c1 } /* Name.Tag */
+.highlight .nv { color: #d8dee9 } /* Name.Variable */
+.highlight .ow { color: #81a1c1; font-weight: bold } /* Operator.Word */
+.highlight .pm { color: #eceff4 } /* Punctuation.Marker */
+.highlight .w { color: #d8dee9 } /* Text.Whitespace */
+.highlight .mb { color: #b48ead } /* Literal.Number.Bin */
+.highlight .mf { color: #b48ead } /* Literal.Number.Float */
+.highlight .mh { color: #b48ead } /* Literal.Number.Hex */
+.highlight .mi { color: #b48ead } /* Literal.Number.Integer */
+.highlight .mo { color: #b48ead } /* Literal.Number.Oct */
+.highlight .sa { color: #a3be8c } /* Literal.String.Affix */
+.highlight .sb { color: #a3be8c } /* Literal.String.Backtick */
+.highlight .sc { color: #a3be8c } /* Literal.String.Char */
+.highlight .dl { color: #a3be8c } /* Literal.String.Delimiter */
+.highlight .sd { color: #616e87 } /* Literal.String.Doc */
+.highlight .s2 { color: #a3be8c } /* Literal.String.Double */
+.highlight .se { color: #ebcb8b } /* Literal.String.Escape */
+.highlight .sh { color: #a3be8c } /* Literal.String.Heredoc */
+.highlight .si { color: #a3be8c } /* Literal.String.Interpol */
+.highlight .sx { color: #a3be8c } /* Literal.String.Other */
+.highlight .sr { color: #ebcb8b } /* Literal.String.Regex */
+.highlight .s1 { color: #a3be8c } /* Literal.String.Single */
+.highlight .ss { color: #a3be8c } /* Literal.String.Symbol */
+.highlight .bp { color: #81a1c1 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #88c0d0 } /* Name.Function.Magic */
+.highlight .vc { color: #d8dee9 } /* Name.Variable.Class */
+.highlight .vg { color: #d8dee9 } /* Name.Variable.Global */
+.highlight .vi { color: #d8dee9 } /* Name.Variable.Instance */
+.highlight .vm { color: #d8dee9 } /* Name.Variable.Magic */
+.highlight .il { color: #b48ead } /* Literal.Number.Integer.Long */

--- a/one-dark.css
+++ b/one-dark.css
@@ -1,0 +1,84 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #282C34; color: #ABB2BF }
+.highlight .c { color: #7F848E } /* Comment */
+.highlight .err { color: #ABB2BF } /* Error */
+.highlight .esc { color: #ABB2BF } /* Escape */
+.highlight .g { color: #ABB2BF } /* Generic */
+.highlight .k { color: #C678DD } /* Keyword */
+.highlight .l { color: #ABB2BF } /* Literal */
+.highlight .n { color: #E06C75 } /* Name */
+.highlight .o { color: #56B6C2 } /* Operator */
+.highlight .x { color: #ABB2BF } /* Other */
+.highlight .p { color: #ABB2BF } /* Punctuation */
+.highlight .ch { color: #7F848E } /* Comment.Hashbang */
+.highlight .cm { color: #7F848E } /* Comment.Multiline */
+.highlight .cp { color: #7F848E } /* Comment.Preproc */
+.highlight .cpf { color: #7F848E } /* Comment.PreprocFile */
+.highlight .c1 { color: #7F848E } /* Comment.Single */
+.highlight .cs { color: #7F848E } /* Comment.Special */
+.highlight .gd { color: #ABB2BF } /* Generic.Deleted */
+.highlight .ge { color: #ABB2BF } /* Generic.Emph */
+.highlight .gr { color: #ABB2BF } /* Generic.Error */
+.highlight .gh { color: #ABB2BF } /* Generic.Heading */
+.highlight .gi { color: #ABB2BF } /* Generic.Inserted */
+.highlight .go { color: #ABB2BF } /* Generic.Output */
+.highlight .gp { color: #ABB2BF } /* Generic.Prompt */
+.highlight .gs { color: #ABB2BF } /* Generic.Strong */
+.highlight .gu { color: #ABB2BF } /* Generic.Subheading */
+.highlight .gt { color: #ABB2BF } /* Generic.Traceback */
+.highlight .kc { color: #E5C07B } /* Keyword.Constant */
+.highlight .kd { color: #C678DD } /* Keyword.Declaration */
+.highlight .kn { color: #C678DD } /* Keyword.Namespace */
+.highlight .kp { color: #C678DD } /* Keyword.Pseudo */
+.highlight .kr { color: #C678DD } /* Keyword.Reserved */
+.highlight .kt { color: #E5C07B } /* Keyword.Type */
+.highlight .ld { color: #ABB2BF } /* Literal.Date */
+.highlight .m { color: #D19A66 } /* Literal.Number */
+.highlight .s { color: #98C379 } /* Literal.String */
+.highlight .na { color: #E06C75 } /* Name.Attribute */
+.highlight .nb { color: #E5C07B } /* Name.Builtin */
+.highlight .nc { color: #E5C07B } /* Name.Class */
+.highlight .no { color: #E06C75 } /* Name.Constant */
+.highlight .nd { color: #61AFEF } /* Name.Decorator */
+.highlight .ni { color: #E06C75 } /* Name.Entity */
+.highlight .ne { color: #E06C75 } /* Name.Exception */
+.highlight .nf { color: #61AFEF; font-weight: bold } /* Name.Function */
+.highlight .nl { color: #E06C75 } /* Name.Label */
+.highlight .nn { color: #E06C75 } /* Name.Namespace */
+.highlight .nx { color: #E06C75 } /* Name.Other */
+.highlight .py { color: #E06C75 } /* Name.Property */
+.highlight .nt { color: #E06C75 } /* Name.Tag */
+.highlight .nv { color: #E06C75 } /* Name.Variable */
+.highlight .ow { color: #56B6C2 } /* Operator.Word */
+.highlight .pm { color: #ABB2BF } /* Punctuation.Marker */
+.highlight .w { color: #ABB2BF } /* Text.Whitespace */
+.highlight .mb { color: #D19A66 } /* Literal.Number.Bin */
+.highlight .mf { color: #D19A66 } /* Literal.Number.Float */
+.highlight .mh { color: #D19A66 } /* Literal.Number.Hex */
+.highlight .mi { color: #D19A66 } /* Literal.Number.Integer */
+.highlight .mo { color: #D19A66 } /* Literal.Number.Oct */
+.highlight .sa { color: #98C379 } /* Literal.String.Affix */
+.highlight .sb { color: #98C379 } /* Literal.String.Backtick */
+.highlight .sc { color: #98C379 } /* Literal.String.Char */
+.highlight .dl { color: #98C379 } /* Literal.String.Delimiter */
+.highlight .sd { color: #98C379 } /* Literal.String.Doc */
+.highlight .s2 { color: #98C379 } /* Literal.String.Double */
+.highlight .se { color: #98C379 } /* Literal.String.Escape */
+.highlight .sh { color: #98C379 } /* Literal.String.Heredoc */
+.highlight .si { color: #98C379 } /* Literal.String.Interpol */
+.highlight .sx { color: #98C379 } /* Literal.String.Other */
+.highlight .sr { color: #98C379 } /* Literal.String.Regex */
+.highlight .s1 { color: #98C379 } /* Literal.String.Single */
+.highlight .ss { color: #98C379 } /* Literal.String.Symbol */
+.highlight .bp { color: #E5C07B } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #56B6C2; font-weight: bold } /* Name.Function.Magic */
+.highlight .vc { color: #E06C75 } /* Name.Variable.Class */
+.highlight .vg { color: #E06C75 } /* Name.Variable.Global */
+.highlight .vi { color: #E06C75 } /* Name.Variable.Instance */
+.highlight .vm { color: #E06C75 } /* Name.Variable.Magic */
+.highlight .il { color: #D19A66 } /* Literal.Number.Integer.Long */

--- a/paraiso-dark.css
+++ b/paraiso-dark.css
@@ -1,0 +1,78 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #4f424c }
+.highlight { background: #2f1e2e; color: #e7e9db }
+.highlight .c { color: #776e71 } /* Comment */
+.highlight .err { color: #ef6155 } /* Error */
+.highlight .k { color: #815ba4 } /* Keyword */
+.highlight .l { color: #f99b15 } /* Literal */
+.highlight .n { color: #e7e9db } /* Name */
+.highlight .o { color: #5bc4bf } /* Operator */
+.highlight .p { color: #e7e9db } /* Punctuation */
+.highlight .ch { color: #776e71 } /* Comment.Hashbang */
+.highlight .cm { color: #776e71 } /* Comment.Multiline */
+.highlight .cp { color: #776e71 } /* Comment.Preproc */
+.highlight .cpf { color: #776e71 } /* Comment.PreprocFile */
+.highlight .c1 { color: #776e71 } /* Comment.Single */
+.highlight .cs { color: #776e71 } /* Comment.Special */
+.highlight .gd { color: #ef6155 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gh { color: #e7e9db; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #48b685 } /* Generic.Inserted */
+.highlight .gp { color: #776e71; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #5bc4bf; font-weight: bold } /* Generic.Subheading */
+.highlight .kc { color: #815ba4 } /* Keyword.Constant */
+.highlight .kd { color: #815ba4 } /* Keyword.Declaration */
+.highlight .kn { color: #5bc4bf } /* Keyword.Namespace */
+.highlight .kp { color: #815ba4 } /* Keyword.Pseudo */
+.highlight .kr { color: #815ba4 } /* Keyword.Reserved */
+.highlight .kt { color: #fec418 } /* Keyword.Type */
+.highlight .ld { color: #48b685 } /* Literal.Date */
+.highlight .m { color: #f99b15 } /* Literal.Number */
+.highlight .s { color: #48b685 } /* Literal.String */
+.highlight .na { color: #06b6ef } /* Name.Attribute */
+.highlight .nb { color: #e7e9db } /* Name.Builtin */
+.highlight .nc { color: #fec418 } /* Name.Class */
+.highlight .no { color: #ef6155 } /* Name.Constant */
+.highlight .nd { color: #5bc4bf } /* Name.Decorator */
+.highlight .ni { color: #e7e9db } /* Name.Entity */
+.highlight .ne { color: #ef6155 } /* Name.Exception */
+.highlight .nf { color: #06b6ef } /* Name.Function */
+.highlight .nl { color: #e7e9db } /* Name.Label */
+.highlight .nn { color: #fec418 } /* Name.Namespace */
+.highlight .nx { color: #06b6ef } /* Name.Other */
+.highlight .py { color: #e7e9db } /* Name.Property */
+.highlight .nt { color: #5bc4bf } /* Name.Tag */
+.highlight .nv { color: #ef6155 } /* Name.Variable */
+.highlight .ow { color: #5bc4bf } /* Operator.Word */
+.highlight .pm { color: #e7e9db } /* Punctuation.Marker */
+.highlight .w { color: #e7e9db } /* Text.Whitespace */
+.highlight .mb { color: #f99b15 } /* Literal.Number.Bin */
+.highlight .mf { color: #f99b15 } /* Literal.Number.Float */
+.highlight .mh { color: #f99b15 } /* Literal.Number.Hex */
+.highlight .mi { color: #f99b15 } /* Literal.Number.Integer */
+.highlight .mo { color: #f99b15 } /* Literal.Number.Oct */
+.highlight .sa { color: #48b685 } /* Literal.String.Affix */
+.highlight .sb { color: #48b685 } /* Literal.String.Backtick */
+.highlight .sc { color: #e7e9db } /* Literal.String.Char */
+.highlight .dl { color: #48b685 } /* Literal.String.Delimiter */
+.highlight .sd { color: #776e71 } /* Literal.String.Doc */
+.highlight .s2 { color: #48b685 } /* Literal.String.Double */
+.highlight .se { color: #f99b15 } /* Literal.String.Escape */
+.highlight .sh { color: #48b685 } /* Literal.String.Heredoc */
+.highlight .si { color: #f99b15 } /* Literal.String.Interpol */
+.highlight .sx { color: #48b685 } /* Literal.String.Other */
+.highlight .sr { color: #48b685 } /* Literal.String.Regex */
+.highlight .s1 { color: #48b685 } /* Literal.String.Single */
+.highlight .ss { color: #48b685 } /* Literal.String.Symbol */
+.highlight .bp { color: #e7e9db } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #06b6ef } /* Name.Function.Magic */
+.highlight .vc { color: #ef6155 } /* Name.Variable.Class */
+.highlight .vg { color: #ef6155 } /* Name.Variable.Global */
+.highlight .vi { color: #ef6155 } /* Name.Variable.Instance */
+.highlight .vm { color: #ef6155 } /* Name.Variable.Magic */
+.highlight .il { color: #f99b15 } /* Literal.Number.Integer.Long */

--- a/paraiso-light.css
+++ b/paraiso-light.css
@@ -1,0 +1,78 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #a39e9b }
+.highlight { background: #e7e9db; color: #2f1e2e }
+.highlight .c { color: #8d8687 } /* Comment */
+.highlight .err { color: #ef6155 } /* Error */
+.highlight .k { color: #815ba4 } /* Keyword */
+.highlight .l { color: #f99b15 } /* Literal */
+.highlight .n { color: #2f1e2e } /* Name */
+.highlight .o { color: #5bc4bf } /* Operator */
+.highlight .p { color: #2f1e2e } /* Punctuation */
+.highlight .ch { color: #8d8687 } /* Comment.Hashbang */
+.highlight .cm { color: #8d8687 } /* Comment.Multiline */
+.highlight .cp { color: #8d8687 } /* Comment.Preproc */
+.highlight .cpf { color: #8d8687 } /* Comment.PreprocFile */
+.highlight .c1 { color: #8d8687 } /* Comment.Single */
+.highlight .cs { color: #8d8687 } /* Comment.Special */
+.highlight .gd { color: #ef6155 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gh { color: #2f1e2e; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #48b685 } /* Generic.Inserted */
+.highlight .gp { color: #8d8687; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #5bc4bf; font-weight: bold } /* Generic.Subheading */
+.highlight .kc { color: #815ba4 } /* Keyword.Constant */
+.highlight .kd { color: #815ba4 } /* Keyword.Declaration */
+.highlight .kn { color: #5bc4bf } /* Keyword.Namespace */
+.highlight .kp { color: #815ba4 } /* Keyword.Pseudo */
+.highlight .kr { color: #815ba4 } /* Keyword.Reserved */
+.highlight .kt { color: #fec418 } /* Keyword.Type */
+.highlight .ld { color: #48b685 } /* Literal.Date */
+.highlight .m { color: #f99b15 } /* Literal.Number */
+.highlight .s { color: #48b685 } /* Literal.String */
+.highlight .na { color: #06b6ef } /* Name.Attribute */
+.highlight .nb { color: #2f1e2e } /* Name.Builtin */
+.highlight .nc { color: #fec418 } /* Name.Class */
+.highlight .no { color: #ef6155 } /* Name.Constant */
+.highlight .nd { color: #5bc4bf } /* Name.Decorator */
+.highlight .ni { color: #2f1e2e } /* Name.Entity */
+.highlight .ne { color: #ef6155 } /* Name.Exception */
+.highlight .nf { color: #06b6ef } /* Name.Function */
+.highlight .nl { color: #2f1e2e } /* Name.Label */
+.highlight .nn { color: #fec418 } /* Name.Namespace */
+.highlight .nx { color: #06b6ef } /* Name.Other */
+.highlight .py { color: #2f1e2e } /* Name.Property */
+.highlight .nt { color: #5bc4bf } /* Name.Tag */
+.highlight .nv { color: #ef6155 } /* Name.Variable */
+.highlight .ow { color: #5bc4bf } /* Operator.Word */
+.highlight .pm { color: #2f1e2e } /* Punctuation.Marker */
+.highlight .w { color: #2f1e2e } /* Text.Whitespace */
+.highlight .mb { color: #f99b15 } /* Literal.Number.Bin */
+.highlight .mf { color: #f99b15 } /* Literal.Number.Float */
+.highlight .mh { color: #f99b15 } /* Literal.Number.Hex */
+.highlight .mi { color: #f99b15 } /* Literal.Number.Integer */
+.highlight .mo { color: #f99b15 } /* Literal.Number.Oct */
+.highlight .sa { color: #48b685 } /* Literal.String.Affix */
+.highlight .sb { color: #48b685 } /* Literal.String.Backtick */
+.highlight .sc { color: #2f1e2e } /* Literal.String.Char */
+.highlight .dl { color: #48b685 } /* Literal.String.Delimiter */
+.highlight .sd { color: #8d8687 } /* Literal.String.Doc */
+.highlight .s2 { color: #48b685 } /* Literal.String.Double */
+.highlight .se { color: #f99b15 } /* Literal.String.Escape */
+.highlight .sh { color: #48b685 } /* Literal.String.Heredoc */
+.highlight .si { color: #f99b15 } /* Literal.String.Interpol */
+.highlight .sx { color: #48b685 } /* Literal.String.Other */
+.highlight .sr { color: #48b685 } /* Literal.String.Regex */
+.highlight .s1 { color: #48b685 } /* Literal.String.Single */
+.highlight .ss { color: #48b685 } /* Literal.String.Symbol */
+.highlight .bp { color: #2f1e2e } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #06b6ef } /* Name.Function.Magic */
+.highlight .vc { color: #ef6155 } /* Name.Variable.Class */
+.highlight .vg { color: #ef6155 } /* Name.Variable.Global */
+.highlight .vi { color: #ef6155 } /* Name.Variable.Instance */
+.highlight .vm { color: #ef6155 } /* Name.Variable.Magic */
+.highlight .il { color: #f99b15 } /* Literal.Number.Integer.Long */

--- a/pastie.css
+++ b/pastie.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #ffffff; }
+.highlight { background: #ffffff; }
 .highlight .c { color: #888888 } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { color: #008800; font-weight: bold } /* Keyword */

--- a/perldoc.css
+++ b/perldoc.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #eeeedd; }
+.highlight { background: #eeeedd; }
 .highlight .c { color: #228B22 } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { color: #8B008B; font-weight: bold } /* Keyword */

--- a/rainbow_dash.css
+++ b/rainbow_dash.css
@@ -1,0 +1,67 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; color: #4d4d4d }
+.highlight .c { color: #0080ff; font-style: italic } /* Comment */
+.highlight .err { color: #ffffff; background-color: #cc0000 } /* Error */
+.highlight .k { color: #2c5dcd; font-weight: bold } /* Keyword */
+.highlight .o { color: #2c5dcd } /* Operator */
+.highlight .ch { color: #0080ff; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #0080ff; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #0080ff } /* Comment.Preproc */
+.highlight .cpf { color: #0080ff; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #0080ff; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #0080ff; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight .gd { background-color: #ffcccc; border: 1px solid #c5060b } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #ff0000 } /* Generic.Error */
+.highlight .gh { color: #2c5dcd; font-weight: bold } /* Generic.Heading */
+.highlight .gi { background-color: #ccffcc; border: 1px solid #00cc00 } /* Generic.Inserted */
+.highlight .go { color: #aaaaaa } /* Generic.Output */
+.highlight .gp { color: #2c5dcd; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #2c5dcd; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #c5060b } /* Generic.Traceback */
+.highlight .kc { color: #2c5dcd; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #2c5dcd; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #2c5dcd; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #2c5dcd } /* Keyword.Pseudo */
+.highlight .kr { color: #2c5dcd; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #5918bb; font-weight: bold } /* Keyword.Type */
+.highlight .m { color: #5918bb; font-weight: bold } /* Literal.Number */
+.highlight .s { color: #00cc66 } /* Literal.String */
+.highlight .na { color: #2c5dcd; font-style: italic } /* Name.Attribute */
+.highlight .nb { color: #5918bb; font-weight: bold } /* Name.Builtin */
+.highlight .nc { text-decoration: underline } /* Name.Class */
+.highlight .no { color: #318495 } /* Name.Constant */
+.highlight .nd { color: #ff8000; font-weight: bold } /* Name.Decorator */
+.highlight .ni { color: #5918bb; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #5918bb; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #ff8000; font-weight: bold } /* Name.Function */
+.highlight .nt { color: #2c5dcd; font-weight: bold } /* Name.Tag */
+.highlight .ow { color: #2c5dcd; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #cbcbcb } /* Text.Whitespace */
+.highlight .mb { color: #5918bb; font-weight: bold } /* Literal.Number.Bin */
+.highlight .mf { color: #5918bb; font-weight: bold } /* Literal.Number.Float */
+.highlight .mh { color: #5918bb; font-weight: bold } /* Literal.Number.Hex */
+.highlight .mi { color: #5918bb; font-weight: bold } /* Literal.Number.Integer */
+.highlight .mo { color: #5918bb; font-weight: bold } /* Literal.Number.Oct */
+.highlight .sa { color: #00cc66 } /* Literal.String.Affix */
+.highlight .sb { color: #00cc66 } /* Literal.String.Backtick */
+.highlight .sc { color: #00cc66 } /* Literal.String.Char */
+.highlight .dl { color: #00cc66 } /* Literal.String.Delimiter */
+.highlight .sd { color: #00cc66; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #00cc66 } /* Literal.String.Double */
+.highlight .se { color: #c5060b; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #00cc66 } /* Literal.String.Heredoc */
+.highlight .si { color: #00cc66 } /* Literal.String.Interpol */
+.highlight .sx { color: #318495 } /* Literal.String.Other */
+.highlight .sr { color: #00cc66 } /* Literal.String.Regex */
+.highlight .s1 { color: #00cc66 } /* Literal.String.Single */
+.highlight .ss { color: #c5060b; font-weight: bold } /* Literal.String.Symbol */
+.highlight .bp { color: #5918bb; font-weight: bold } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #ff8000; font-weight: bold } /* Name.Function.Magic */
+.highlight .il { color: #5918bb; font-weight: bold } /* Literal.Number.Integer.Long */

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Pygments==2.2.0
+Pygments==2.13.0

--- a/rrt.css
+++ b/rrt.css
@@ -1,0 +1,84 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #0000ff }
+.highlight { background: #000000; color: #dddddd }
+.highlight .c { color: #00ff00 } /* Comment */
+.highlight .err { color: #dddddd } /* Error */
+.highlight .esc { color: #dddddd } /* Escape */
+.highlight .g { color: #dddddd } /* Generic */
+.highlight .k { color: #ff0000 } /* Keyword */
+.highlight .l { color: #dddddd } /* Literal */
+.highlight .n { color: #dddddd } /* Name */
+.highlight .o { color: #dddddd } /* Operator */
+.highlight .x { color: #dddddd } /* Other */
+.highlight .p { color: #dddddd } /* Punctuation */
+.highlight .ch { color: #00ff00 } /* Comment.Hashbang */
+.highlight .cm { color: #00ff00 } /* Comment.Multiline */
+.highlight .cp { color: #e5e5e5 } /* Comment.Preproc */
+.highlight .cpf { color: #00ff00 } /* Comment.PreprocFile */
+.highlight .c1 { color: #00ff00 } /* Comment.Single */
+.highlight .cs { color: #00ff00 } /* Comment.Special */
+.highlight .gd { color: #dddddd } /* Generic.Deleted */
+.highlight .ge { color: #dddddd } /* Generic.Emph */
+.highlight .gr { color: #dddddd } /* Generic.Error */
+.highlight .gh { color: #dddddd } /* Generic.Heading */
+.highlight .gi { color: #dddddd } /* Generic.Inserted */
+.highlight .go { color: #dddddd } /* Generic.Output */
+.highlight .gp { color: #dddddd } /* Generic.Prompt */
+.highlight .gs { color: #dddddd } /* Generic.Strong */
+.highlight .gu { color: #dddddd } /* Generic.Subheading */
+.highlight .gt { color: #dddddd } /* Generic.Traceback */
+.highlight .kc { color: #ff0000 } /* Keyword.Constant */
+.highlight .kd { color: #ff0000 } /* Keyword.Declaration */
+.highlight .kn { color: #ff0000 } /* Keyword.Namespace */
+.highlight .kp { color: #ff0000 } /* Keyword.Pseudo */
+.highlight .kr { color: #ff0000 } /* Keyword.Reserved */
+.highlight .kt { color: #ee82ee } /* Keyword.Type */
+.highlight .ld { color: #dddddd } /* Literal.Date */
+.highlight .m { color: #dddddd } /* Literal.Number */
+.highlight .s { color: #87ceeb } /* Literal.String */
+.highlight .na { color: #dddddd } /* Name.Attribute */
+.highlight .nb { color: #dddddd } /* Name.Builtin */
+.highlight .nc { color: #dddddd } /* Name.Class */
+.highlight .no { color: #7fffd4 } /* Name.Constant */
+.highlight .nd { color: #dddddd } /* Name.Decorator */
+.highlight .ni { color: #dddddd } /* Name.Entity */
+.highlight .ne { color: #dddddd } /* Name.Exception */
+.highlight .nf { color: #ffff00 } /* Name.Function */
+.highlight .nl { color: #dddddd } /* Name.Label */
+.highlight .nn { color: #dddddd } /* Name.Namespace */
+.highlight .nx { color: #dddddd } /* Name.Other */
+.highlight .py { color: #dddddd } /* Name.Property */
+.highlight .nt { color: #dddddd } /* Name.Tag */
+.highlight .nv { color: #eedd82 } /* Name.Variable */
+.highlight .ow { color: #dddddd } /* Operator.Word */
+.highlight .pm { color: #dddddd } /* Punctuation.Marker */
+.highlight .w { color: #dddddd } /* Text.Whitespace */
+.highlight .mb { color: #dddddd } /* Literal.Number.Bin */
+.highlight .mf { color: #dddddd } /* Literal.Number.Float */
+.highlight .mh { color: #dddddd } /* Literal.Number.Hex */
+.highlight .mi { color: #dddddd } /* Literal.Number.Integer */
+.highlight .mo { color: #dddddd } /* Literal.Number.Oct */
+.highlight .sa { color: #87ceeb } /* Literal.String.Affix */
+.highlight .sb { color: #87ceeb } /* Literal.String.Backtick */
+.highlight .sc { color: #87ceeb } /* Literal.String.Char */
+.highlight .dl { color: #87ceeb } /* Literal.String.Delimiter */
+.highlight .sd { color: #87ceeb } /* Literal.String.Doc */
+.highlight .s2 { color: #87ceeb } /* Literal.String.Double */
+.highlight .se { color: #87ceeb } /* Literal.String.Escape */
+.highlight .sh { color: #87ceeb } /* Literal.String.Heredoc */
+.highlight .si { color: #87ceeb } /* Literal.String.Interpol */
+.highlight .sx { color: #87ceeb } /* Literal.String.Other */
+.highlight .sr { color: #87ceeb } /* Literal.String.Regex */
+.highlight .s1 { color: #87ceeb } /* Literal.String.Single */
+.highlight .ss { color: #87ceeb } /* Literal.String.Symbol */
+.highlight .bp { color: #dddddd } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #ffff00 } /* Name.Function.Magic */
+.highlight .vc { color: #eedd82 } /* Name.Variable.Class */
+.highlight .vg { color: #eedd82 } /* Name.Variable.Global */
+.highlight .vi { color: #eedd82 } /* Name.Variable.Instance */
+.highlight .vm { color: #eedd82 } /* Name.Variable.Magic */
+.highlight .il { color: #dddddd } /* Literal.Number.Integer.Long */

--- a/sas.css
+++ b/sas.css
@@ -1,0 +1,65 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; }
+.highlight .c { color: #008800; font-style: italic } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight .g { color: #2c2cff } /* Generic */
+.highlight .k { color: #2c2cff } /* Keyword */
+.highlight .x { background-color: #ffffe0 } /* Other */
+.highlight .ch { color: #008800; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #008800; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #008800; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #008800; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #008800; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #008800; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #2c2cff } /* Generic.Deleted */
+.highlight .ge { color: #008800 } /* Generic.Emph */
+.highlight .gr { color: #d30202 } /* Generic.Error */
+.highlight .gh { color: #2c2cff } /* Generic.Heading */
+.highlight .gi { color: #2c2cff } /* Generic.Inserted */
+.highlight .go { color: #2c2cff } /* Generic.Output */
+.highlight .gp { color: #2c2cff } /* Generic.Prompt */
+.highlight .gs { color: #2c2cff } /* Generic.Strong */
+.highlight .gu { color: #2c2cff } /* Generic.Subheading */
+.highlight .gt { color: #2c2cff } /* Generic.Traceback */
+.highlight .kc { color: #2c2cff; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #2c2cff } /* Keyword.Declaration */
+.highlight .kn { color: #2c2cff } /* Keyword.Namespace */
+.highlight .kp { color: #2c2cff } /* Keyword.Pseudo */
+.highlight .kr { color: #353580; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #2c2cff } /* Keyword.Type */
+.highlight .m { color: #2c8553; font-weight: bold } /* Literal.Number */
+.highlight .s { color: #800080 } /* Literal.String */
+.highlight .nb { color: #2c2cff } /* Name.Builtin */
+.highlight .nf { font-weight: bold; font-style: italic } /* Name.Function */
+.highlight .nv { color: #2c2cff; font-weight: bold } /* Name.Variable */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #2c8553; font-weight: bold } /* Literal.Number.Bin */
+.highlight .mf { color: #2c8553; font-weight: bold } /* Literal.Number.Float */
+.highlight .mh { color: #2c8553; font-weight: bold } /* Literal.Number.Hex */
+.highlight .mi { color: #2c8553; font-weight: bold } /* Literal.Number.Integer */
+.highlight .mo { color: #2c8553; font-weight: bold } /* Literal.Number.Oct */
+.highlight .sa { color: #800080 } /* Literal.String.Affix */
+.highlight .sb { color: #800080 } /* Literal.String.Backtick */
+.highlight .sc { color: #800080 } /* Literal.String.Char */
+.highlight .dl { color: #800080 } /* Literal.String.Delimiter */
+.highlight .sd { color: #800080 } /* Literal.String.Doc */
+.highlight .s2 { color: #800080 } /* Literal.String.Double */
+.highlight .se { color: #800080 } /* Literal.String.Escape */
+.highlight .sh { color: #800080 } /* Literal.String.Heredoc */
+.highlight .si { color: #800080 } /* Literal.String.Interpol */
+.highlight .sx { color: #800080 } /* Literal.String.Other */
+.highlight .sr { color: #800080 } /* Literal.String.Regex */
+.highlight .s1 { color: #800080 } /* Literal.String.Single */
+.highlight .ss { color: #800080 } /* Literal.String.Symbol */
+.highlight .bp { color: #2c2cff } /* Name.Builtin.Pseudo */
+.highlight .fm { font-weight: bold; font-style: italic } /* Name.Function.Magic */
+.highlight .vc { color: #2c2cff; font-weight: bold } /* Name.Variable.Class */
+.highlight .vg { color: #2c2cff; font-weight: bold } /* Name.Variable.Global */
+.highlight .vi { color: #2c2cff; font-weight: bold } /* Name.Variable.Instance */
+.highlight .vm { color: #2c2cff; font-weight: bold } /* Name.Variable.Magic */
+.highlight .il { color: #2c8553; font-weight: bold } /* Literal.Number.Integer.Long */

--- a/solarized-dark.css
+++ b/solarized-dark.css
@@ -1,0 +1,84 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: #586e75; background-color: #073642; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: #586e75; background-color: #073642; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #073642 }
+.highlight { background: #002b36; color: #839496 }
+.highlight .c { color: #586e75; font-style: italic } /* Comment */
+.highlight .err { color: #839496; background-color: #dc322f } /* Error */
+.highlight .esc { color: #839496 } /* Escape */
+.highlight .g { color: #839496 } /* Generic */
+.highlight .k { color: #859900 } /* Keyword */
+.highlight .l { color: #839496 } /* Literal */
+.highlight .n { color: #839496 } /* Name */
+.highlight .o { color: #586e75 } /* Operator */
+.highlight .x { color: #839496 } /* Other */
+.highlight .p { color: #839496 } /* Punctuation */
+.highlight .ch { color: #586e75; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #586e75; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #d33682 } /* Comment.Preproc */
+.highlight .cpf { color: #586e75 } /* Comment.PreprocFile */
+.highlight .c1 { color: #586e75; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #586e75; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #dc322f } /* Generic.Deleted */
+.highlight .ge { color: #839496; font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #dc322f } /* Generic.Error */
+.highlight .gh { color: #839496; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #859900 } /* Generic.Inserted */
+.highlight .go { color: #839496 } /* Generic.Output */
+.highlight .gp { color: #268bd2; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { color: #839496; font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #839496; text-decoration: underline } /* Generic.Subheading */
+.highlight .gt { color: #268bd2 } /* Generic.Traceback */
+.highlight .kc { color: #2aa198 } /* Keyword.Constant */
+.highlight .kd { color: #2aa198 } /* Keyword.Declaration */
+.highlight .kn { color: #cb4b16 } /* Keyword.Namespace */
+.highlight .kp { color: #859900 } /* Keyword.Pseudo */
+.highlight .kr { color: #859900 } /* Keyword.Reserved */
+.highlight .kt { color: #b58900 } /* Keyword.Type */
+.highlight .ld { color: #839496 } /* Literal.Date */
+.highlight .m { color: #2aa198 } /* Literal.Number */
+.highlight .s { color: #2aa198 } /* Literal.String */
+.highlight .na { color: #839496 } /* Name.Attribute */
+.highlight .nb { color: #268bd2 } /* Name.Builtin */
+.highlight .nc { color: #268bd2 } /* Name.Class */
+.highlight .no { color: #268bd2 } /* Name.Constant */
+.highlight .nd { color: #268bd2 } /* Name.Decorator */
+.highlight .ni { color: #268bd2 } /* Name.Entity */
+.highlight .ne { color: #268bd2 } /* Name.Exception */
+.highlight .nf { color: #268bd2 } /* Name.Function */
+.highlight .nl { color: #268bd2 } /* Name.Label */
+.highlight .nn { color: #268bd2 } /* Name.Namespace */
+.highlight .nx { color: #839496 } /* Name.Other */
+.highlight .py { color: #839496 } /* Name.Property */
+.highlight .nt { color: #268bd2 } /* Name.Tag */
+.highlight .nv { color: #268bd2 } /* Name.Variable */
+.highlight .ow { color: #859900 } /* Operator.Word */
+.highlight .pm { color: #839496 } /* Punctuation.Marker */
+.highlight .w { color: #839496 } /* Text.Whitespace */
+.highlight .mb { color: #2aa198 } /* Literal.Number.Bin */
+.highlight .mf { color: #2aa198 } /* Literal.Number.Float */
+.highlight .mh { color: #2aa198 } /* Literal.Number.Hex */
+.highlight .mi { color: #2aa198 } /* Literal.Number.Integer */
+.highlight .mo { color: #2aa198 } /* Literal.Number.Oct */
+.highlight .sa { color: #2aa198 } /* Literal.String.Affix */
+.highlight .sb { color: #2aa198 } /* Literal.String.Backtick */
+.highlight .sc { color: #2aa198 } /* Literal.String.Char */
+.highlight .dl { color: #2aa198 } /* Literal.String.Delimiter */
+.highlight .sd { color: #586e75 } /* Literal.String.Doc */
+.highlight .s2 { color: #2aa198 } /* Literal.String.Double */
+.highlight .se { color: #2aa198 } /* Literal.String.Escape */
+.highlight .sh { color: #2aa198 } /* Literal.String.Heredoc */
+.highlight .si { color: #2aa198 } /* Literal.String.Interpol */
+.highlight .sx { color: #2aa198 } /* Literal.String.Other */
+.highlight .sr { color: #cb4b16 } /* Literal.String.Regex */
+.highlight .s1 { color: #2aa198 } /* Literal.String.Single */
+.highlight .ss { color: #2aa198 } /* Literal.String.Symbol */
+.highlight .bp { color: #268bd2 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #268bd2 } /* Name.Function.Magic */
+.highlight .vc { color: #268bd2 } /* Name.Variable.Class */
+.highlight .vg { color: #268bd2 } /* Name.Variable.Global */
+.highlight .vi { color: #268bd2 } /* Name.Variable.Instance */
+.highlight .vm { color: #268bd2 } /* Name.Variable.Magic */
+.highlight .il { color: #2aa198 } /* Literal.Number.Integer.Long */

--- a/solarized-light.css
+++ b/solarized-light.css
@@ -1,0 +1,84 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: #93a1a1; background-color: #eee8d5; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: #93a1a1; background-color: #eee8d5; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #eee8d5 }
+.highlight { background: #fdf6e3; color: #657b83 }
+.highlight .c { color: #93a1a1; font-style: italic } /* Comment */
+.highlight .err { color: #657b83; background-color: #dc322f } /* Error */
+.highlight .esc { color: #657b83 } /* Escape */
+.highlight .g { color: #657b83 } /* Generic */
+.highlight .k { color: #859900 } /* Keyword */
+.highlight .l { color: #657b83 } /* Literal */
+.highlight .n { color: #657b83 } /* Name */
+.highlight .o { color: #93a1a1 } /* Operator */
+.highlight .x { color: #657b83 } /* Other */
+.highlight .p { color: #657b83 } /* Punctuation */
+.highlight .ch { color: #93a1a1; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #93a1a1; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #d33682 } /* Comment.Preproc */
+.highlight .cpf { color: #93a1a1 } /* Comment.PreprocFile */
+.highlight .c1 { color: #93a1a1; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #93a1a1; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #dc322f } /* Generic.Deleted */
+.highlight .ge { color: #657b83; font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #dc322f } /* Generic.Error */
+.highlight .gh { color: #657b83; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #859900 } /* Generic.Inserted */
+.highlight .go { color: #657b83 } /* Generic.Output */
+.highlight .gp { color: #268bd2; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { color: #657b83; font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #657b83; text-decoration: underline } /* Generic.Subheading */
+.highlight .gt { color: #268bd2 } /* Generic.Traceback */
+.highlight .kc { color: #2aa198 } /* Keyword.Constant */
+.highlight .kd { color: #2aa198 } /* Keyword.Declaration */
+.highlight .kn { color: #cb4b16 } /* Keyword.Namespace */
+.highlight .kp { color: #859900 } /* Keyword.Pseudo */
+.highlight .kr { color: #859900 } /* Keyword.Reserved */
+.highlight .kt { color: #b58900 } /* Keyword.Type */
+.highlight .ld { color: #657b83 } /* Literal.Date */
+.highlight .m { color: #2aa198 } /* Literal.Number */
+.highlight .s { color: #2aa198 } /* Literal.String */
+.highlight .na { color: #657b83 } /* Name.Attribute */
+.highlight .nb { color: #268bd2 } /* Name.Builtin */
+.highlight .nc { color: #268bd2 } /* Name.Class */
+.highlight .no { color: #268bd2 } /* Name.Constant */
+.highlight .nd { color: #268bd2 } /* Name.Decorator */
+.highlight .ni { color: #268bd2 } /* Name.Entity */
+.highlight .ne { color: #268bd2 } /* Name.Exception */
+.highlight .nf { color: #268bd2 } /* Name.Function */
+.highlight .nl { color: #268bd2 } /* Name.Label */
+.highlight .nn { color: #268bd2 } /* Name.Namespace */
+.highlight .nx { color: #657b83 } /* Name.Other */
+.highlight .py { color: #657b83 } /* Name.Property */
+.highlight .nt { color: #268bd2 } /* Name.Tag */
+.highlight .nv { color: #268bd2 } /* Name.Variable */
+.highlight .ow { color: #859900 } /* Operator.Word */
+.highlight .pm { color: #657b83 } /* Punctuation.Marker */
+.highlight .w { color: #657b83 } /* Text.Whitespace */
+.highlight .mb { color: #2aa198 } /* Literal.Number.Bin */
+.highlight .mf { color: #2aa198 } /* Literal.Number.Float */
+.highlight .mh { color: #2aa198 } /* Literal.Number.Hex */
+.highlight .mi { color: #2aa198 } /* Literal.Number.Integer */
+.highlight .mo { color: #2aa198 } /* Literal.Number.Oct */
+.highlight .sa { color: #2aa198 } /* Literal.String.Affix */
+.highlight .sb { color: #2aa198 } /* Literal.String.Backtick */
+.highlight .sc { color: #2aa198 } /* Literal.String.Char */
+.highlight .dl { color: #2aa198 } /* Literal.String.Delimiter */
+.highlight .sd { color: #93a1a1 } /* Literal.String.Doc */
+.highlight .s2 { color: #2aa198 } /* Literal.String.Double */
+.highlight .se { color: #2aa198 } /* Literal.String.Escape */
+.highlight .sh { color: #2aa198 } /* Literal.String.Heredoc */
+.highlight .si { color: #2aa198 } /* Literal.String.Interpol */
+.highlight .sx { color: #2aa198 } /* Literal.String.Other */
+.highlight .sr { color: #cb4b16 } /* Literal.String.Regex */
+.highlight .s1 { color: #2aa198 } /* Literal.String.Single */
+.highlight .ss { color: #2aa198 } /* Literal.String.Symbol */
+.highlight .bp { color: #268bd2 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #268bd2 } /* Name.Function.Magic */
+.highlight .vc { color: #268bd2 } /* Name.Variable.Class */
+.highlight .vg { color: #268bd2 } /* Name.Variable.Global */
+.highlight .vi { color: #268bd2 } /* Name.Variable.Instance */
+.highlight .vm { color: #268bd2 } /* Name.Variable.Magic */
+.highlight .il { color: #2aa198 } /* Literal.Number.Integer.Long */

--- a/staroffice.css
+++ b/staroffice.css
@@ -1,0 +1,84 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; color: #000080 }
+.highlight .c { color: #696969 } /* Comment */
+.highlight .err { color: #800000 } /* Error */
+.highlight .esc { color: #000080 } /* Escape */
+.highlight .g { color: #000080 } /* Generic */
+.highlight .k { color: #000080 } /* Keyword */
+.highlight .l { color: #EE0000 } /* Literal */
+.highlight .n { color: #008000 } /* Name */
+.highlight .o { color: #000080 } /* Operator */
+.highlight .x { color: #000080 } /* Other */
+.highlight .p { color: #000080 } /* Punctuation */
+.highlight .ch { color: #696969 } /* Comment.Hashbang */
+.highlight .cm { color: #696969 } /* Comment.Multiline */
+.highlight .cp { color: #696969 } /* Comment.Preproc */
+.highlight .cpf { color: #696969 } /* Comment.PreprocFile */
+.highlight .c1 { color: #696969 } /* Comment.Single */
+.highlight .cs { color: #696969 } /* Comment.Special */
+.highlight .gd { color: #000080 } /* Generic.Deleted */
+.highlight .ge { color: #000080 } /* Generic.Emph */
+.highlight .gr { color: #000080 } /* Generic.Error */
+.highlight .gh { color: #000080 } /* Generic.Heading */
+.highlight .gi { color: #000080 } /* Generic.Inserted */
+.highlight .go { color: #000080 } /* Generic.Output */
+.highlight .gp { color: #000080 } /* Generic.Prompt */
+.highlight .gs { color: #000080 } /* Generic.Strong */
+.highlight .gu { color: #000080 } /* Generic.Subheading */
+.highlight .gt { color: #000080 } /* Generic.Traceback */
+.highlight .kc { color: #000080 } /* Keyword.Constant */
+.highlight .kd { color: #000080 } /* Keyword.Declaration */
+.highlight .kn { color: #000080 } /* Keyword.Namespace */
+.highlight .kp { color: #000080 } /* Keyword.Pseudo */
+.highlight .kr { color: #000080 } /* Keyword.Reserved */
+.highlight .kt { color: #000080 } /* Keyword.Type */
+.highlight .ld { color: #EE0000 } /* Literal.Date */
+.highlight .m { color: #EE0000 } /* Literal.Number */
+.highlight .s { color: #EE0000 } /* Literal.String */
+.highlight .na { color: #008000 } /* Name.Attribute */
+.highlight .nb { color: #008000 } /* Name.Builtin */
+.highlight .nc { color: #008000 } /* Name.Class */
+.highlight .no { color: #008000 } /* Name.Constant */
+.highlight .nd { color: #008000 } /* Name.Decorator */
+.highlight .ni { color: #008000 } /* Name.Entity */
+.highlight .ne { color: #008000 } /* Name.Exception */
+.highlight .nf { color: #008000 } /* Name.Function */
+.highlight .nl { color: #008000 } /* Name.Label */
+.highlight .nn { color: #008000 } /* Name.Namespace */
+.highlight .nx { color: #008000 } /* Name.Other */
+.highlight .py { color: #008000 } /* Name.Property */
+.highlight .nt { color: #008000 } /* Name.Tag */
+.highlight .nv { color: #008000 } /* Name.Variable */
+.highlight .ow { color: #000080 } /* Operator.Word */
+.highlight .pm { color: #000080 } /* Punctuation.Marker */
+.highlight .w { color: #000080 } /* Text.Whitespace */
+.highlight .mb { color: #EE0000 } /* Literal.Number.Bin */
+.highlight .mf { color: #EE0000 } /* Literal.Number.Float */
+.highlight .mh { color: #EE0000 } /* Literal.Number.Hex */
+.highlight .mi { color: #EE0000 } /* Literal.Number.Integer */
+.highlight .mo { color: #EE0000 } /* Literal.Number.Oct */
+.highlight .sa { color: #EE0000 } /* Literal.String.Affix */
+.highlight .sb { color: #EE0000 } /* Literal.String.Backtick */
+.highlight .sc { color: #EE0000 } /* Literal.String.Char */
+.highlight .dl { color: #EE0000 } /* Literal.String.Delimiter */
+.highlight .sd { color: #EE0000 } /* Literal.String.Doc */
+.highlight .s2 { color: #EE0000 } /* Literal.String.Double */
+.highlight .se { color: #EE0000 } /* Literal.String.Escape */
+.highlight .sh { color: #EE0000 } /* Literal.String.Heredoc */
+.highlight .si { color: #EE0000 } /* Literal.String.Interpol */
+.highlight .sx { color: #EE0000 } /* Literal.String.Other */
+.highlight .sr { color: #EE0000 } /* Literal.String.Regex */
+.highlight .s1 { color: #EE0000 } /* Literal.String.Single */
+.highlight .ss { color: #EE0000 } /* Literal.String.Symbol */
+.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #008000 } /* Name.Function.Magic */
+.highlight .vc { color: #008000 } /* Name.Variable.Class */
+.highlight .vg { color: #008000 } /* Name.Variable.Global */
+.highlight .vi { color: #008000 } /* Name.Variable.Instance */
+.highlight .vm { color: #008000 } /* Name.Variable.Magic */
+.highlight .il { color: #EE0000 } /* Literal.Number.Integer.Long */

--- a/stata-dark.css
+++ b/stata-dark.css
@@ -1,0 +1,84 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #49483e }
+.highlight { background: #232629; color: #cccccc }
+.highlight .c { color: #777777; font-style: italic } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight .esc { color: #cccccc } /* Escape */
+.highlight .g { color: #cccccc } /* Generic */
+.highlight .k { color: #7686bb; font-weight: bold } /* Keyword */
+.highlight .l { color: #cccccc } /* Literal */
+.highlight .n { color: #cccccc } /* Name */
+.highlight .o { color: #cccccc } /* Operator */
+.highlight .x { color: #cccccc } /* Other */
+.highlight .p { color: #cccccc } /* Punctuation */
+.highlight .ch { color: #777777; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #777777; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #777777; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #777777; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #777777; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #777777; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #cccccc } /* Generic.Deleted */
+.highlight .ge { color: #cccccc } /* Generic.Emph */
+.highlight .gr { color: #cccccc } /* Generic.Error */
+.highlight .gh { color: #cccccc } /* Generic.Heading */
+.highlight .gi { color: #cccccc } /* Generic.Inserted */
+.highlight .go { color: #cccccc } /* Generic.Output */
+.highlight .gp { color: #ffffff } /* Generic.Prompt */
+.highlight .gs { color: #cccccc } /* Generic.Strong */
+.highlight .gu { color: #cccccc } /* Generic.Subheading */
+.highlight .gt { color: #cccccc } /* Generic.Traceback */
+.highlight .kc { color: #7686bb; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #7686bb; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #7686bb; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #7686bb; font-weight: bold } /* Keyword.Pseudo */
+.highlight .kr { color: #7686bb; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #7686bb; font-weight: bold } /* Keyword.Type */
+.highlight .ld { color: #cccccc } /* Literal.Date */
+.highlight .m { color: #4FB8CC } /* Literal.Number */
+.highlight .s { color: #51cc99 } /* Literal.String */
+.highlight .na { color: #cccccc } /* Name.Attribute */
+.highlight .nb { color: #cccccc } /* Name.Builtin */
+.highlight .nc { color: #cccccc } /* Name.Class */
+.highlight .no { color: #cccccc } /* Name.Constant */
+.highlight .nd { color: #cccccc } /* Name.Decorator */
+.highlight .ni { color: #cccccc } /* Name.Entity */
+.highlight .ne { color: #cccccc } /* Name.Exception */
+.highlight .nf { color: #6a6aff } /* Name.Function */
+.highlight .nl { color: #cccccc } /* Name.Label */
+.highlight .nn { color: #cccccc } /* Name.Namespace */
+.highlight .nx { color: #e2828e } /* Name.Other */
+.highlight .py { color: #cccccc } /* Name.Property */
+.highlight .nt { color: #cccccc } /* Name.Tag */
+.highlight .nv { color: #7AB4DB; font-weight: bold } /* Name.Variable */
+.highlight .ow { color: #cccccc } /* Operator.Word */
+.highlight .pm { color: #cccccc } /* Punctuation.Marker */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #4FB8CC } /* Literal.Number.Bin */
+.highlight .mf { color: #4FB8CC } /* Literal.Number.Float */
+.highlight .mh { color: #4FB8CC } /* Literal.Number.Hex */
+.highlight .mi { color: #4FB8CC } /* Literal.Number.Integer */
+.highlight .mo { color: #4FB8CC } /* Literal.Number.Oct */
+.highlight .sa { color: #51cc99 } /* Literal.String.Affix */
+.highlight .sb { color: #51cc99 } /* Literal.String.Backtick */
+.highlight .sc { color: #51cc99 } /* Literal.String.Char */
+.highlight .dl { color: #51cc99 } /* Literal.String.Delimiter */
+.highlight .sd { color: #51cc99 } /* Literal.String.Doc */
+.highlight .s2 { color: #51cc99 } /* Literal.String.Double */
+.highlight .se { color: #51cc99 } /* Literal.String.Escape */
+.highlight .sh { color: #51cc99 } /* Literal.String.Heredoc */
+.highlight .si { color: #51cc99 } /* Literal.String.Interpol */
+.highlight .sx { color: #51cc99 } /* Literal.String.Other */
+.highlight .sr { color: #51cc99 } /* Literal.String.Regex */
+.highlight .s1 { color: #51cc99 } /* Literal.String.Single */
+.highlight .ss { color: #51cc99 } /* Literal.String.Symbol */
+.highlight .bp { color: #cccccc } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #6a6aff } /* Name.Function.Magic */
+.highlight .vc { color: #7AB4DB; font-weight: bold } /* Name.Variable.Class */
+.highlight .vg { color: #BE646C; font-weight: bold } /* Name.Variable.Global */
+.highlight .vi { color: #7AB4DB; font-weight: bold } /* Name.Variable.Instance */
+.highlight .vm { color: #7AB4DB; font-weight: bold } /* Name.Variable.Magic */
+.highlight .il { color: #4FB8CC } /* Literal.Number.Integer.Long */

--- a/stata-light.css
+++ b/stata-light.css
@@ -1,0 +1,52 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; color: #111111 }
+.highlight .c { color: #008800; font-style: italic } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight .k { color: #353580; font-weight: bold } /* Keyword */
+.highlight .ch { color: #008800; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #008800; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #008800; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #008800; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #008800; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #008800; font-style: italic } /* Comment.Special */
+.highlight .kc { color: #353580; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #353580; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #353580; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #353580; font-weight: bold } /* Keyword.Pseudo */
+.highlight .kr { color: #353580; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #353580; font-weight: bold } /* Keyword.Type */
+.highlight .m { color: #2c2cff } /* Literal.Number */
+.highlight .s { color: #7a2424 } /* Literal.String */
+.highlight .nf { color: #2c2cff } /* Name.Function */
+.highlight .nx { color: #be646c } /* Name.Other */
+.highlight .nv { color: #35baba; font-weight: bold } /* Name.Variable */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #2c2cff } /* Literal.Number.Bin */
+.highlight .mf { color: #2c2cff } /* Literal.Number.Float */
+.highlight .mh { color: #2c2cff } /* Literal.Number.Hex */
+.highlight .mi { color: #2c2cff } /* Literal.Number.Integer */
+.highlight .mo { color: #2c2cff } /* Literal.Number.Oct */
+.highlight .sa { color: #7a2424 } /* Literal.String.Affix */
+.highlight .sb { color: #7a2424 } /* Literal.String.Backtick */
+.highlight .sc { color: #7a2424 } /* Literal.String.Char */
+.highlight .dl { color: #7a2424 } /* Literal.String.Delimiter */
+.highlight .sd { color: #7a2424 } /* Literal.String.Doc */
+.highlight .s2 { color: #7a2424 } /* Literal.String.Double */
+.highlight .se { color: #7a2424 } /* Literal.String.Escape */
+.highlight .sh { color: #7a2424 } /* Literal.String.Heredoc */
+.highlight .si { color: #7a2424 } /* Literal.String.Interpol */
+.highlight .sx { color: #7a2424 } /* Literal.String.Other */
+.highlight .sr { color: #7a2424 } /* Literal.String.Regex */
+.highlight .s1 { color: #7a2424 } /* Literal.String.Single */
+.highlight .ss { color: #7a2424 } /* Literal.String.Symbol */
+.highlight .fm { color: #2c2cff } /* Name.Function.Magic */
+.highlight .vc { color: #35baba; font-weight: bold } /* Name.Variable.Class */
+.highlight .vg { color: #b5565e; font-weight: bold } /* Name.Variable.Global */
+.highlight .vi { color: #35baba; font-weight: bold } /* Name.Variable.Instance */
+.highlight .vm { color: #35baba; font-weight: bold } /* Name.Variable.Magic */
+.highlight .il { color: #2c2cff } /* Literal.Number.Integer.Long */

--- a/stata.css
+++ b/stata.css
@@ -1,0 +1,52 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; color: #111111 }
+.highlight .c { color: #008800; font-style: italic } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight .k { color: #353580; font-weight: bold } /* Keyword */
+.highlight .ch { color: #008800; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #008800; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #008800; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #008800; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #008800; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #008800; font-style: italic } /* Comment.Special */
+.highlight .kc { color: #353580; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #353580; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #353580; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #353580; font-weight: bold } /* Keyword.Pseudo */
+.highlight .kr { color: #353580; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #353580; font-weight: bold } /* Keyword.Type */
+.highlight .m { color: #2c2cff } /* Literal.Number */
+.highlight .s { color: #7a2424 } /* Literal.String */
+.highlight .nf { color: #2c2cff } /* Name.Function */
+.highlight .nx { color: #be646c } /* Name.Other */
+.highlight .nv { color: #35baba; font-weight: bold } /* Name.Variable */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #2c2cff } /* Literal.Number.Bin */
+.highlight .mf { color: #2c2cff } /* Literal.Number.Float */
+.highlight .mh { color: #2c2cff } /* Literal.Number.Hex */
+.highlight .mi { color: #2c2cff } /* Literal.Number.Integer */
+.highlight .mo { color: #2c2cff } /* Literal.Number.Oct */
+.highlight .sa { color: #7a2424 } /* Literal.String.Affix */
+.highlight .sb { color: #7a2424 } /* Literal.String.Backtick */
+.highlight .sc { color: #7a2424 } /* Literal.String.Char */
+.highlight .dl { color: #7a2424 } /* Literal.String.Delimiter */
+.highlight .sd { color: #7a2424 } /* Literal.String.Doc */
+.highlight .s2 { color: #7a2424 } /* Literal.String.Double */
+.highlight .se { color: #7a2424 } /* Literal.String.Escape */
+.highlight .sh { color: #7a2424 } /* Literal.String.Heredoc */
+.highlight .si { color: #7a2424 } /* Literal.String.Interpol */
+.highlight .sx { color: #7a2424 } /* Literal.String.Other */
+.highlight .sr { color: #7a2424 } /* Literal.String.Regex */
+.highlight .s1 { color: #7a2424 } /* Literal.String.Single */
+.highlight .ss { color: #7a2424 } /* Literal.String.Symbol */
+.highlight .fm { color: #2c2cff } /* Name.Function.Magic */
+.highlight .vc { color: #35baba; font-weight: bold } /* Name.Variable.Class */
+.highlight .vg { color: #b5565e; font-weight: bold } /* Name.Variable.Global */
+.highlight .vi { color: #35baba; font-weight: bold } /* Name.Variable.Instance */
+.highlight .vm { color: #35baba; font-weight: bold } /* Name.Variable.Magic */
+.highlight .il { color: #2c2cff } /* Literal.Number.Integer.Long */

--- a/tango.css
+++ b/tango.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #f8f8f8; }
+.highlight { background: #f8f8f8; }
 .highlight .c { color: #8f5902; font-style: italic } /* Comment */
 .highlight .err { color: #a40000; border: 1px solid #ef2929 } /* Error */
 .highlight .g { color: #000000 } /* Generic */
@@ -49,7 +54,8 @@
 .highlight .nt { color: #204a87; font-weight: bold } /* Name.Tag */
 .highlight .nv { color: #000000 } /* Name.Variable */
 .highlight .ow { color: #204a87; font-weight: bold } /* Operator.Word */
-.highlight .w { color: #f8f8f8; text-decoration: underline } /* Text.Whitespace */
+.highlight .pm { color: #000000; font-weight: bold } /* Punctuation.Marker */
+.highlight .w { color: #f8f8f8 } /* Text.Whitespace */
 .highlight .mb { color: #0000cf; font-weight: bold } /* Literal.Number.Bin */
 .highlight .mf { color: #0000cf; font-weight: bold } /* Literal.Number.Float */
 .highlight .mh { color: #0000cf; font-weight: bold } /* Literal.Number.Hex */

--- a/trac.css
+++ b/trac.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #ffffff; }
+.highlight { background: #ffffff; }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { font-weight: bold } /* Keyword */

--- a/vim.css
+++ b/vim.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #222222 }
-.highlight  { background: #000000; color: #cccccc }
+.highlight { background: #000000; color: #cccccc }
 .highlight .c { color: #000080 } /* Comment */
 .highlight .err { color: #cccccc; border: 1px solid #FF0000 } /* Error */
 .highlight .esc { color: #cccccc } /* Escape */
@@ -50,6 +55,7 @@
 .highlight .nt { color: #cccccc } /* Name.Tag */
 .highlight .nv { color: #00cdcd } /* Name.Variable */
 .highlight .ow { color: #cdcd00 } /* Operator.Word */
+.highlight .pm { color: #cccccc } /* Punctuation.Marker */
 .highlight .w { color: #cccccc } /* Text.Whitespace */
 .highlight .mb { color: #cd00cd } /* Literal.Number.Bin */
 .highlight .mf { color: #cd00cd } /* Literal.Number.Float */

--- a/vs.css
+++ b/vs.css
@@ -1,5 +1,10 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
 .highlight .hll { background-color: #ffffcc }
-.highlight  { background: #ffffff; }
+.highlight { background: #ffffff; }
 .highlight .c { color: #008000 } /* Comment */
 .highlight .err { border: 1px solid #FF0000 } /* Error */
 .highlight .k { color: #0000ff } /* Keyword */

--- a/xcode.css
+++ b/xcode.css
@@ -1,0 +1,68 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #ffffcc }
+.highlight { background: #ffffff; }
+.highlight .c { color: #177500 } /* Comment */
+.highlight .err { color: #000000 } /* Error */
+.highlight .k { color: #A90D91 } /* Keyword */
+.highlight .l { color: #1C01CE } /* Literal */
+.highlight .n { color: #000000 } /* Name */
+.highlight .o { color: #000000 } /* Operator */
+.highlight .ch { color: #177500 } /* Comment.Hashbang */
+.highlight .cm { color: #177500 } /* Comment.Multiline */
+.highlight .cp { color: #633820 } /* Comment.Preproc */
+.highlight .cpf { color: #177500 } /* Comment.PreprocFile */
+.highlight .c1 { color: #177500 } /* Comment.Single */
+.highlight .cs { color: #177500 } /* Comment.Special */
+.highlight .kc { color: #A90D91 } /* Keyword.Constant */
+.highlight .kd { color: #A90D91 } /* Keyword.Declaration */
+.highlight .kn { color: #A90D91 } /* Keyword.Namespace */
+.highlight .kp { color: #A90D91 } /* Keyword.Pseudo */
+.highlight .kr { color: #A90D91 } /* Keyword.Reserved */
+.highlight .kt { color: #A90D91 } /* Keyword.Type */
+.highlight .ld { color: #1C01CE } /* Literal.Date */
+.highlight .m { color: #1C01CE } /* Literal.Number */
+.highlight .s { color: #C41A16 } /* Literal.String */
+.highlight .na { color: #836C28 } /* Name.Attribute */
+.highlight .nb { color: #A90D91 } /* Name.Builtin */
+.highlight .nc { color: #3F6E75 } /* Name.Class */
+.highlight .no { color: #000000 } /* Name.Constant */
+.highlight .nd { color: #000000 } /* Name.Decorator */
+.highlight .ni { color: #000000 } /* Name.Entity */
+.highlight .ne { color: #000000 } /* Name.Exception */
+.highlight .nf { color: #000000 } /* Name.Function */
+.highlight .nl { color: #000000 } /* Name.Label */
+.highlight .nn { color: #000000 } /* Name.Namespace */
+.highlight .nx { color: #000000 } /* Name.Other */
+.highlight .py { color: #000000 } /* Name.Property */
+.highlight .nt { color: #000000 } /* Name.Tag */
+.highlight .nv { color: #000000 } /* Name.Variable */
+.highlight .ow { color: #000000 } /* Operator.Word */
+.highlight .mb { color: #1C01CE } /* Literal.Number.Bin */
+.highlight .mf { color: #1C01CE } /* Literal.Number.Float */
+.highlight .mh { color: #1C01CE } /* Literal.Number.Hex */
+.highlight .mi { color: #1C01CE } /* Literal.Number.Integer */
+.highlight .mo { color: #1C01CE } /* Literal.Number.Oct */
+.highlight .sa { color: #C41A16 } /* Literal.String.Affix */
+.highlight .sb { color: #C41A16 } /* Literal.String.Backtick */
+.highlight .sc { color: #2300CE } /* Literal.String.Char */
+.highlight .dl { color: #C41A16 } /* Literal.String.Delimiter */
+.highlight .sd { color: #C41A16 } /* Literal.String.Doc */
+.highlight .s2 { color: #C41A16 } /* Literal.String.Double */
+.highlight .se { color: #C41A16 } /* Literal.String.Escape */
+.highlight .sh { color: #C41A16 } /* Literal.String.Heredoc */
+.highlight .si { color: #C41A16 } /* Literal.String.Interpol */
+.highlight .sx { color: #C41A16 } /* Literal.String.Other */
+.highlight .sr { color: #C41A16 } /* Literal.String.Regex */
+.highlight .s1 { color: #C41A16 } /* Literal.String.Single */
+.highlight .ss { color: #C41A16 } /* Literal.String.Symbol */
+.highlight .bp { color: #5B269A } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #000000 } /* Name.Function.Magic */
+.highlight .vc { color: #000000 } /* Name.Variable.Class */
+.highlight .vg { color: #000000 } /* Name.Variable.Global */
+.highlight .vi { color: #000000 } /* Name.Variable.Instance */
+.highlight .vm { color: #000000 } /* Name.Variable.Magic */
+.highlight .il { color: #1C01CE } /* Literal.Number.Integer.Long */

--- a/zenburn.css
+++ b/zenburn.css
@@ -1,0 +1,84 @@
+pre { line-height: 125%; }
+td.linenos .normal { color: #5d6262; background-color: #353535; padding-left: 5px; padding-right: 5px; }
+span.linenos { color: #5d6262; background-color: #353535; padding-left: 5px; padding-right: 5px; }
+td.linenos .special { color: #7a8080; background-color: #353535; padding-left: 5px; padding-right: 5px; }
+span.linenos.special { color: #7a8080; background-color: #353535; padding-left: 5px; padding-right: 5px; }
+.highlight .hll { background-color: #484848 }
+.highlight { background: #3f3f3f; color: #dcdccc }
+.highlight .c { color: #7f9f7f; font-style: italic } /* Comment */
+.highlight .err { color: #e37170; font-weight: bold } /* Error */
+.highlight .esc { color: #dcdccc } /* Escape */
+.highlight .g { color: #ecbcbc; font-weight: bold } /* Generic */
+.highlight .k { color: #efdcbc } /* Keyword */
+.highlight .l { color: #9fafaf } /* Literal */
+.highlight .n { color: #dcdccc } /* Name */
+.highlight .o { color: #f0efd0 } /* Operator */
+.highlight .x { color: #dcdccc } /* Other */
+.highlight .p { color: #f0efd0 } /* Punctuation */
+.highlight .ch { color: #7f9f7f; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #7f9f7f; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #dfaf8f; font-weight: bold; font-style: italic } /* Comment.Preproc */
+.highlight .cpf { color: #cc9393; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #7f9f7f; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #dfdfdf; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #c3bf9f; font-weight: bold; background-color: #313c36 } /* Generic.Deleted */
+.highlight .ge { color: #ffffff; font-weight: bold } /* Generic.Emph */
+.highlight .gr { color: #ecbcbc; font-weight: bold } /* Generic.Error */
+.highlight .gh { color: #efefef; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #709080; font-weight: bold; background-color: #313c36 } /* Generic.Inserted */
+.highlight .go { color: #5b605e; font-weight: bold } /* Generic.Output */
+.highlight .gp { color: #ecbcbc; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { color: #ecbcbc; font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #efefef; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #80d4aa; font-weight: bold; background-color: #2f2f2f } /* Generic.Traceback */
+.highlight .kc { color: #dca3a3 } /* Keyword.Constant */
+.highlight .kd { color: #f0dfaf } /* Keyword.Declaration */
+.highlight .kn { color: #f0dfaf } /* Keyword.Namespace */
+.highlight .kp { color: #efdcbc } /* Keyword.Pseudo */
+.highlight .kr { color: #efdcbc } /* Keyword.Reserved */
+.highlight .kt { color: #dfdfbf; font-weight: bold } /* Keyword.Type */
+.highlight .ld { color: #9fafaf } /* Literal.Date */
+.highlight .m { color: #8cd0d3 } /* Literal.Number */
+.highlight .s { color: #cc9393 } /* Literal.String */
+.highlight .na { color: #efef8f } /* Name.Attribute */
+.highlight .nb { color: #efef8f } /* Name.Builtin */
+.highlight .nc { color: #efef8f } /* Name.Class */
+.highlight .no { color: #dca3a3 } /* Name.Constant */
+.highlight .nd { color: #dcdccc } /* Name.Decorator */
+.highlight .ni { color: #cfbfaf } /* Name.Entity */
+.highlight .ne { color: #c3bf9f; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #efef8f } /* Name.Function */
+.highlight .nl { color: #dcdccc } /* Name.Label */
+.highlight .nn { color: #dcdccc } /* Name.Namespace */
+.highlight .nx { color: #dcdccc } /* Name.Other */
+.highlight .py { color: #dcdccc } /* Name.Property */
+.highlight .nt { color: #e89393; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #dcdccc } /* Name.Variable */
+.highlight .ow { color: #f0efd0 } /* Operator.Word */
+.highlight .pm { color: #f0efd0 } /* Punctuation.Marker */
+.highlight .w { color: #dcdccc } /* Text.Whitespace */
+.highlight .mb { color: #8cd0d3 } /* Literal.Number.Bin */
+.highlight .mf { color: #c0bed1 } /* Literal.Number.Float */
+.highlight .mh { color: #8cd0d3 } /* Literal.Number.Hex */
+.highlight .mi { color: #8cd0d3 } /* Literal.Number.Integer */
+.highlight .mo { color: #8cd0d3 } /* Literal.Number.Oct */
+.highlight .sa { color: #cc9393 } /* Literal.String.Affix */
+.highlight .sb { color: #cc9393 } /* Literal.String.Backtick */
+.highlight .sc { color: #cc9393 } /* Literal.String.Char */
+.highlight .dl { color: #cc9393 } /* Literal.String.Delimiter */
+.highlight .sd { color: #7f9f7f } /* Literal.String.Doc */
+.highlight .s2 { color: #cc9393 } /* Literal.String.Double */
+.highlight .se { color: #cc9393 } /* Literal.String.Escape */
+.highlight .sh { color: #cc9393 } /* Literal.String.Heredoc */
+.highlight .si { color: #dca3a3; font-weight: bold } /* Literal.String.Interpol */
+.highlight .sx { color: #cc9393 } /* Literal.String.Other */
+.highlight .sr { color: #cc9393 } /* Literal.String.Regex */
+.highlight .s1 { color: #cc9393 } /* Literal.String.Single */
+.highlight .ss { color: #cc9393 } /* Literal.String.Symbol */
+.highlight .bp { color: #dcdccc } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #efef8f } /* Name.Function.Magic */
+.highlight .vc { color: #dcdccc } /* Name.Variable.Class */
+.highlight .vg { color: #dcdccc } /* Name.Variable.Global */
+.highlight .vi { color: #dcdccc } /* Name.Variable.Instance */
+.highlight .vm { color: #dcdccc } /* Name.Variable.Magic */
+.highlight .il { color: #8cd0d3 } /* Literal.Number.Integer.Long */


### PR DESCRIPTION
This PR also updates the makefile to fetch all available styles (using `pygments.styles.get_all_styles`, available since v0.6).

I'll keep this PR up to date with Pygments releases for as long as it's open.